### PR TITLE
detect and load additional metadata recursively

### DIFF
--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -118,8 +118,8 @@ class ChildProject:
         md.sort_values('basename', ascending = False, inplace = True)
 
         duplicates = md.groupby('basename').agg(
-            paths = ('path', lambda l: ','.join(l)),
-            count = ('path', len)
+            paths = pd.NamedAgg(column = 'path', aggfunc = lambda l: ','.join(l)),
+            count = pd.NamedAgg(column = 'path', aggfunc = len),
         )
         duplicates = duplicates[duplicates['count'] >= 2].reset_index()
 

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -118,14 +118,14 @@ class ChildProject:
         md.sort_values('basename', ascending = False, inplace = True)
 
         duplicates = md.groupby('basename').agg(
-            paths = pd.NamedAgg(column = 'path', aggfunc = lambda l: ','.join(l)),
-            count = pd.NamedAgg(column = 'path', aggfunc = len),
+            paths = ('path', list),
+            count = ('path', len),
         )
         duplicates = duplicates[duplicates['count'] >= 2].reset_index()
 
         if len(duplicates):
             raise Exception("ambiguous filenames detected:\n{}".format(
-                '\n'.join(duplicates.apply(lambda d: "{} found as {}".format(d['basename'], d['paths']), axis = 1).tolist())
+                '\n'.join(duplicates.apply(lambda d: "{} found as {}".format(','.join(d['basename']), d['paths']), axis = 1).tolist())
             ))
 
         for md in md['path'].tolist():

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -56,7 +56,7 @@ class ChildProject:
         IndexColumn(name = 'date_iso', description = 'date in which recording was started in ISO (eg 2020-09-17)', required = True, datetime = '%Y-%m-%d'),
         IndexColumn(name = 'start_time', description = 'local time in which recording was started in format 24-hour (H)H:MM; if minutes are unknown, use 00. Set as ‘NA’ if unknown.', required = True, datetime = '%H:%M'),
         IndexColumn(name = 'recording_device_type', description = 'lena, usb, olympus, babylogger (lowercase)', required = True, choices = ['lena', 'usb', 'olympus', 'babylogger']),
-        IndexColumn(name = 'recording_filename', description = 'the path to the file from the root of “recordings”), set to ‘NA’ if no valid recording available. It is unique (two recordings cannot point towards the same file).', required = True, filename = True, unique = True),
+        IndexColumn(name = 'recording_filename', description = 'the path to the file from the root of “recordings”). It MUST be unique (two recordings cannot point towards the same file).', required = True, filename = True, unique = True),
         IndexColumn(name = 'duration', description = 'duration of the audio, in milliseconds', regex = r'([0-9]+)'),
         IndexColumn(name = 'session_id', description = 'identifier of the recording session.'),
         IndexColumn(name = 'session_offset', description = 'offset (in milliseconds) of the recording with respect to other recordings that are part of the same session. Each recording session is identified by their `session_id`.', regex = r'[0-9]+'),
@@ -111,11 +111,12 @@ class ChildProject:
 
         additional_children_md = []
         children_md_path = os.path.join(metadata_path, 'children')
-        
+
         if os.path.exists(children_md_path):
             additional_children_md = sorted(
                 glob.glob(os.path.join(children_md_path, '**/*.csv'), recursive = True),
-                key = os.path.basename
+                key = os.path.basename,
+                reverse = True
             )
 
             for md in additional_children_md:
@@ -138,7 +139,8 @@ class ChildProject:
         if os.path.exists(recordings_md_path):
             additional_recordings_md = sorted(
                 glob.glob(os.path.join(recordings_md_path, '**/*.csv'), recursive = True),
-                key = os.path.basename
+                key = os.path.basename,
+                reverse = True
             )
 
             for md in additional_recordings_md:

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -96,10 +96,12 @@ class ChildProject:
         self.children = None
         self.recordings = None
 
+        self.children_metadata_origin = None
+        self.recordings_metadata_origin = None
+
         self.converted_recordings_hashtable = {}
 
     def accumulate_metadata(self, table: str, df: pd.DataFrame, columns: list, merge_column: str) -> pd.DataFrame:
-        additional_md = []
         md_path = os.path.join(self.path, 'metadata', table)
 
         if os.path.exists(md_path):

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -57,22 +57,52 @@ the standards detailed right below.
 Metadata
 --------
 
-children notebook
+Children notebook
 ~~~~~~~~~~~~~~~~~
 
-The children dataframe needs to be saved at ``metadata/children.csv``.
+The children metadata dataframe needs to be saved at ``metadata/children.csv``.
 
 .. index-table:: Children metadata
    :header: children
 
-recording notebook
-~~~~~~~~~~~~~~~~~~
 
-The recordings dataframe needs to be saved at
+Recordings notebook
+~~~~~~~~~~~~~~~~~~~
+
+The recordings metadata dataframe needs to be saved at
 ``metadata/recordings.csv``.
 
 .. index-table:: Recordings metadata
    :header: recordings
+
+Splitting the metadata in several files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, access to parts of the metadata should be limited
+to a list of authorized users. This can be achieved by moving confidential
+information out of the main notebook to a separate CSV file to
+be only delivered to authorized users. These additional files
+should be placed according to the table below:
+
+
+.. csv-table:: Additional metadata
+   :header: data,main notebook,location of additional notebooks
+
+   children,``metadata/children.csv``,``metadata/children/``
+   recordings,``metadata/recordings.csv``,``metadata/recordings/``
+
+There can be as many additional notebooks as necessary, and recursion
+if permitted.
+
+.. note::
+
+   In case two or more notebooks contain the same column, the files
+   whose names come first in alphabetical order will prevail while
+   loading the dataset with our package. For instance, if
+   ``child_dob`` is specified in both  ``metadata/recordings/0_private.csv``
+   and ``metadata/recordings/1_public.csv``, the values in the former file will prevail if it is available.
+   This is useful when anonymized values for a certain parameter still need to be shared,
+   but should replaced with the true values for those who have access to the full dataset.
 
 Annotations
 -----------

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -92,7 +92,7 @@ should be placed according to the table below:
    recordings,``metadata/recordings.csv``,``metadata/recordings/``
 
 There can be as many additional notebooks as necessary, and recursion
-if permitted.
+is permitted.
 
 .. note::
 
@@ -102,7 +102,14 @@ if permitted.
    ``child_dob`` is specified in both  ``metadata/recordings/0_private.csv``
    and ``metadata/recordings/1_public.csv``, the values in the former file will prevail if it is available.
    This is useful when anonymized values for a certain parameter still need to be shared,
-   but should replaced with the true values for those who have access to the full dataset.
+   but should be replaced with the true values for those who have access to the full dataset.
+
+.. warning::
+
+   For recursive metadata, two dataframes cannot share the same basename.
+   For instance, if one dataframe is located at `metadata/children/dates-of-birth.csv`,
+   an error will be thrown if another dataframe exists at
+   `metadata/children/private/dates-of-birth.csv `.
 
 Annotations
 -----------

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -75,8 +75,8 @@ The recordings metadata dataframe needs to be saved at
 .. index-table:: Recordings metadata
    :header: recordings
 
-Splitting the metadata in several files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Splitting the metadata across several files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, access to parts of the metadata should be limited
 to a list of authorized users. This can be achieved by moving confidential

--- a/examples/valid_raw_data/metadata/children/0_test.csv
+++ b/examples/valid_raw_data/metadata/children/0_test.csv
@@ -1,0 +1,2 @@
+child_id,child_dob
+1,2020-01-01

--- a/examples/valid_raw_data/metadata/recordings/0_confidential.csv
+++ b/examples/valid_raw_data/metadata/recordings/0_confidential.csv
@@ -1,0 +1,2 @@
+recording_filename,date_iso
+sound.wav,2020-04-20

--- a/examples/valid_raw_data/metadata/recordings/1_very_confidential.csv
+++ b/examples/valid_raw_data/metadata/recordings/1_very_confidential.csv
@@ -1,0 +1,2 @@
+recording_filename,notes
+sound.wav,"VERY confidential notes"


### PR DESCRIPTION
### Description

Currently, recordings and children metadata are assumed to be entirely stored in metadata/recordings.csv and metadata/children.csv respectively. However, in case users spread their metadata across several files (e.g. to achieve multi-tier access), then there is no standard.

I suggest the standard should be that additional metadata belong as extra CSVs in metadata/recordings and metadata/children respectively. These folders are optional.

If the package detects them, it will list all CSVs from these folders **recursively**,  sort them alphabetically (currently based on their basename, which might be ambiguous), then merge them sequentially.

For instance, if recordings/0.csv and recordings/1.csv exist,
the package will :

 - load metadata/recordings.csv as a dataframe
 - load recordings/0.csv, merge it with the previous dataframe; in case of duplicate columns, recordings/0.csv will prevail
 - load recordings/1.csv, merge it with the previous dataframe; in case of duplicate columns, recordings/1.csv will prevail

etc.

### Status

- [x] tests
- [x] documentation
- [ ] implementation 
    - [x] merge additional metadata recursively (alphabetical order)
    - [ ] improve tests so that they can identify problematic files... this is a big change.