### PR TITLE
excluding segments after sampling

### DIFF
--- a/ChildProject/pipelines/samplers.py
+++ b/ChildProject/pipelines/samplers.py
@@ -698,6 +698,6 @@ class SamplerPipeline(Pipeline):
         )
 
         parser.add_argument('--exclude',
-            help = "path to a CSV dataframe containing the list of segments to exclude",
+            help = "path to a CSV dataframe containing the list of segments to exclude. The columns should be: recording_filename, segment_onset and segment_offset.",
             default = None
         )

--- a/ChildProject/pipelines/samplers.py
+++ b/ChildProject/pipelines/samplers.py
@@ -184,12 +184,14 @@ class Sampler(ABC):
 class CustomSampler(Sampler):
     def __init__(self,
         project: ChildProject.projects.ChildProject,
-        segments_path: str):
+        segments_path: str,
+        recordings: Union[str, List[str], pd.DataFrame] = None,
+        exclude: Union[str, pd.DataFrame] = None):
 
-        super().__init__(project)
+        super().__init__(project, recordings, exclude)
         self.segments_path = segments_path
 
-    def sample(self: str):
+    def _sample(self: str):
         self.segments = pd.read_csv(self.segments_path)
 
         if 'time_seek' not in self.segments.columns:

--- a/ChildProject/pipelines/samplers.py
+++ b/ChildProject/pipelines/samplers.py
@@ -123,8 +123,6 @@ class Sampler(ABC):
 
         segments = []
         for recording, _segments in self.segments.groupby('recording_filename'):
-            print(recording)
-            print(_segments)
             sampled = Timeline(
                 segments = [
                     Segment(segment_onset, segment_offset)
@@ -140,7 +138,7 @@ class Sampler(ABC):
                 ]
             )
 
-            # sampled = sampled.extrude(sampled)
+            # sampled = sampled.extrude(sampled) # not released yet
             extent_tl = Timeline([sampled.extent()], uri = sampled.uri)
             truncating_support = excl.gaps(support = extent_tl)
             sampled = sampled.crop(truncating_support, mode = 'intersection')

--- a/ChildProject/pipelines/samplers.py
+++ b/ChildProject/pipelines/samplers.py
@@ -116,10 +116,10 @@ class Sampler(ABC):
         return segments
 
     def remove_excluded(self):
-        from pyannote.core import Segment, Timeline
-
         if len(self.excluded) == 0:
             return
+
+        from pyannote.core import Segment, Timeline
 
         segments = []
         for recording, _segments in self.segments.groupby('recording_filename'):

--- a/docs/source/elan.rst
+++ b/docs/source/elan.rst
@@ -1,3 +1,5 @@
+.. _eaf-builder:
+
 ELAN builder
 ============
 

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -14,17 +14,23 @@ Overview
 A sampler draws segments from the recordings, according to the algorithm and the parameters defined by the user.
 The sampler will produce two files into the `destination` folder :
 
- - `segments_YYYYMMDD_HHMMSS.csv`, a CSV dataframe of all sampled segments, with three columns: ``recording_filename``, ``segment_onset`` and ``segment_offset``.
- - `parameters_YYYYMMDD_HHMMSS.yml`, a Yaml file with all the parameters that were used to generate the samples.
+ - ``segments_YYYYMMDD_HHMMSS.csv``, a CSV dataframe of all sampled segments, with three columns: ``recording_filename``, ``segment_onset`` and ``segment_offset``.
+ - ``parameters_YYYYMMDD_HHMMSS.yml``, a Yaml file with all the parameters that were used to generate the samples.
 
 If the folder `destination` does not exist, it is automatically created in the process.
 
 Several samplers are implemented in our package, which are listed below.
-The samples can then feed downstream pipelines such as the :ref:`zooniverse` pipeline.
+
+The samples can then feed downstream pipelines such as the :ref:`zooniverse` pipeline or the :ref:`eaf-builder`.
 
 .. clidoc::
 
    child-project sampler --help
+
+All samplers have a few parameters in common:
+
+- ``--recordings``, which sets the white-list of recordings to sample from
+- ``--exclude``, which defines the portions of audio to exclude from the samples *after* sampling.
 
 Periodic sampler
 ~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 chardet==3.0.4
 click==7.1.1
 datalad
+keyring==21.4.0; python_version < "3.8"
 jinja2
 librosa
 lxml

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -137,3 +137,34 @@ def test_filter(project):
         caught_value_error = True
     
     assert caught_value_error == True
+
+def test_exclusion(project):
+    excluded = pd.DataFrame(
+        [['sound.wav', 250, 750], ['sound.wav', 2000, 4000]],
+        columns = ['recording_filename', 'segment_onset', 'segment_offset']
+    )
+
+    sampler = PeriodicSampler(
+        project = project,
+        length = 1000,
+        period = 1000,
+        exclude = excluded      
+    )
+    segments = sampler.sample()\
+        .sort_values(['recording_filename', 'segment_onset', 'segment_offset'])
+
+    pd.testing.assert_frame_equal(
+        segments[segments['recording_filename'] == 'sound.wav'],
+        pd.DataFrame(
+            [['sound.wav', 0, 250], ['sound.wav', 750, 1000]],
+            columns = ['recording_filename', 'segment_onset', 'segment_offset']
+        )
+    )
+
+    pd.testing.assert_frame_equal(
+        segments[segments['recording_filename'] == 'sound2.wav'],
+        pd.DataFrame(
+            [['sound2.wav', 0, 1000], ['sound2.wav', 2000, 3000]],
+            columns = ['recording_filename', 'segment_onset', 'segment_offset']
+        )
+    )


### PR DESCRIPTION
This PR introduces a --exclude parameter for all samplers.
This parameter accepts a dataframe with 3 columns:

1. recording_filename
2. segment_onset
3. segment_offset

If this dataframe is defined, these segments will be automatically removed from sampled segments after sampling.

- [x] tests
- [x] documentation
- [x] implementation