### PR TITLE
Cmdline/audio correlation

### DIFF
--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -1204,11 +1204,11 @@ class AnnotationManager:
         :type end: str
         :param errors: how to deal with invalid start_time values for the recordings. Takes the same values as ``pandas.to_datetime``.
         :type errors: str
-        :return: a DataFrame of annotations;
-        For each row, ``range_onset`` and ``range_offset`` are clipped within the desired clock-time range.
-        The clock-time corresponding to the onset and offset of each annotation
-        is stored in two newly created columns named ``range_onset_time`` and ``range_offset_time``.
-        If the input annotation exceeds 24 hours, one row per matching interval is returned.
+        :return: a DataFrame of annotations; \
+        For each row, ``range_onset`` and ``range_offset`` are clipped within the desired clock-time range. \
+        The clock-time corresponding to the onset and offset of each annotation \
+        is stored in two newly created columns named ``range_onset_time`` and ``range_offset_time``. \
+        If the input annotation exceeds 24 hours, one row per matching interval is returned. \
         :rtype: pd.DataFrame
         """
 
@@ -1318,10 +1318,10 @@ class AnnotationManager:
         :type onset: str, optional
         :param offset: column storing the offset timestamp in milliseconds, defaults to "segment_offset"
         :type offset: str, optional
-        :return: Returns the input dataframe with two new columns ``onset_time`` and ``offset_time``.
-        ``onset_time`` is a datetime object corresponding to the onset of the segment.
-        ``offset_time`` is a datetime object corresponding to the offset of the segment.
-        In case either ``start_time`` or ``date_iso`` is not specified for the corresponding recording,
+        :return: Returns the input dataframe with two new columns ``onset_time`` and ``offset_time``. \
+        ``onset_time`` is a datetime object corresponding to the onset of the segment. \
+        ``offset_time`` is a datetime object corresponding to the offset of the segment. \
+        In case either ``start_time`` or ``date_iso`` is not specified for the corresponding recording, \
         both values will be set to NaT.
         :rtype: pd.DataFrame
         """

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -517,7 +517,7 @@ def compute_durations(args):
     ]
 )
 def correlate_audio(args):
-    """computes the correlation between 2 given audio files of the dataset over a limited duration. Similarity scores are outputted for each frame of the audio, the printed score represents the frame with the highest difference between the two files. <GIVE HERE AN IDEA OF WHAT SCORES ARE FOUND FOR SIMILAR FILES AND DIFFERENT ONES>"""
+    """computes the difference between 2 given audio files of the dataset. A divergence score is outputted, it is the average difference of audio signal over the considered sample (random point in the audio, fixed duration). Divergence scores lower than 0.1 indicate a strong proximity"""
     
     project = ChildProject(args.source)
     project.read()
@@ -548,15 +548,16 @@ def correlate_audio(args):
     else:
         offset = random.uniform(0, dur - interval)/1000
     
-    shift = abs(calculate_shift(
+    avg,size = calculate_shift(
         project.get_recording_path(rec1['recording_filename'].iloc[0],args.profile),
         project.get_recording_path(rec2['recording_filename'].iloc[0],args.profile),
         offset,
         offset,
         interval/1000
-    ))
+    )
     
-    print('{} and {} have a similarity score of {} . Scores lower than 0.01 indicate a strong possibility that the 2 files are similar. Scores higher than 1 indicate a sizable difference'.format(args.audio1,args.audio2,shift))
+    if size < 48000 : print('WARNING : the number of values ({}) in the sample is low, raise the interval value, if possible, for a more reliable analysis'.format(size))
+    print('RESULTS :\nscore < 0.1 => the 2 files seem very similar\nscore > 1   => sizable difference\nscore = {} over a sample of {} values'.format(avg,size))
 
 def main():
     register_pipeline("process", AudioProcessingPipeline)

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -516,7 +516,7 @@ def compute_durations(args):
         arg("--interval", help="duration in minutes of the window used to build the correlation score", default=5, type=int),
     ]
 )
-def correlate_audio(args):
+def compare_recordings(args):
     """computes the difference between 2 given audio files of the dataset. A divergence score is outputted, it is the average difference of audio signal over the considered sample (random point in the audio, fixed duration). Divergence scores lower than 0.1 indicate a strong proximity"""
     
     project = ChildProject(args.source)
@@ -557,7 +557,7 @@ def correlate_audio(args):
     )
     
     if size < 48000 : print('WARNING : the number of values ({}) in the sample is low, raise the interval value, if possible, for a more reliable analysis'.format(size))
-    print('RESULTS :\nscore < 0.1 => the 2 files seem very similar\nscore > 1   => sizable difference\nscore = {} over a sample of {} values'.format(avg,size))
+    print('RESULTS :\ndivergence score = {} over a sample of {} values\nREFERENCE :\ndivergence score < 0.1 => the 2 files seem very similar\ndivergence score > 1   => sizable difference'.format(avg,size))
 
 def main():
     register_pipeline("process", AudioProcessingPipeline)

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -556,7 +556,7 @@ def correlate_audio(args):
         interval/1000
     ))
     
-    print('{} and {} have a similarity score of {} . Scores lower than 0.01 indicate a strong possibility that the 2 files are similar. Scores higher than 0 indicate a sizable difference'.format(args.audio1,args.audio2,shift))
+    print('{} and {} have a similarity score of {} . Scores lower than 0.01 indicate a strong possibility that the 2 files are similar. Scores higher than 1 indicate a sizable difference'.format(args.audio1,args.audio2,shift))
 
 def main():
     register_pipeline("process", AudioProcessingPipeline)

--- a/ChildProject/metrics.py
+++ b/ChildProject/metrics.py
@@ -186,8 +186,8 @@ def conf_matrix(rows_grid, columns_grid):
 def vectors_to_annotation_task(*args, drop: List[str] = []):
     """transform vectors of labels into a nltk AnnotationTask object.
 
-    :param *args: vector of labels for each annotator; add one argument per annotator.
-    :type *args: 1d np.array() of labels
+    :param args: vector of labels for each annotator; add one argument per annotator.
+    :type args: 1d np.array() of labels
     :param drop: list of labels that should be ignored
     :type drop: List[str]
     :return: the AnnotationTask object

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -90,7 +90,7 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
             test_rate = new_rate
         
     if ref_chan != test_chan: #if different number of channels, shrink if possible
-        print('WARNING : different number of channels, attempting to compress channels to carry on with correlation analysis while reducing information on the higher channel file')
+        print('WARNING : different number of channels, attempting to compress channels to carry on with analysis')
         if ref_chan == 1 and test_chan > 1 :
             test = np.mean(test,axis=0)
             test_chan = 1

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -1,4 +1,7 @@
 import os
+import wave
+from scipy.fftpack import fft, ifft
+import numpy as np
 
 def path_is_parent(parent_path: str, child_path: str):
     # Smooth out relative path names, note: if you are concerned about symbolic links, you should use os.path.realpath too
@@ -59,3 +62,52 @@ def get_audio_duration(filename):
         pass
 
     return duration
+
+#reads a wav file for a given start point and duration (both in seconds)
+def read_wav(filename, start_s, length_s):
+    fp = wave.open(filename)
+    samples = fp.getnframes()
+    sampling_rate = fp.getframerate()
+    audio = fp.readframes(samples)
+
+    audio_as_np_int16 = np.frombuffer(audio, dtype=np.int16, offset = int(start_s*sampling_rate), count=int(length_s*sampling_rate+1))
+    audio_as_np_float32 = audio_as_np_int16.astype(np.float32)
+    
+    max_int16 = 2**15
+    audio_normalised = audio_as_np_float32 / max_int16
+
+    return audio_normalised, sampling_rate
+
+#computes a list of similarity scores, each value being for 1 frame of audio
+#returns the most differing value
+def calculate_shift(file1, file2, start1, start2, interval, correlation_output = None):
+    ref, ref_rate = read_wav(file1, start1, interval)
+    test, test_rate = read_wav(file2, start2, interval)
+
+    if ref_rate != test_rate:
+        raise Exception('audios do not match')
+
+    sampling_rate = ref_rate
+
+    downsampled_rate = 400
+    ref = ref[::int(sampling_rate/downsampled_rate)]
+    test = test[::int(sampling_rate/downsampled_rate)]
+
+    ref_padded = np.concatenate((np.zeros(len(ref)-1), ref))
+    test_padded = np.concatenate((test, np.zeros(len(ref)-len(test)+len(ref)-1)))
+
+    ref_fft = fft(ref_padded)
+    test_fft = fft(test_padded)
+
+    cross_spectral_density = ref_fft*np.conj(test_fft)
+    cross_correlations = ifft(cross_spectral_density)
+
+    mag_cross_correlations = np.abs(cross_correlations)
+
+    if correlation_output:
+        np.savetxt(correlation_output, mag_cross_correlations, delimiter = ' ')
+
+    #take the highest differing frame score
+    shift = np.argmax(mag_cross_correlations) - max(len(ref),len(test))
+
+    return shift/downsampled_rate

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -1,5 +1,5 @@
 import os
-import wave
+import librosa
 from scipy.fftpack import fft, ifft
 import numpy as np
 
@@ -65,19 +65,11 @@ def get_audio_duration(filename):
 
 #reads a wav file for a given start point and duration (both in seconds)
 def read_wav(filename, start_s, length_s):
-    fp = wave.open(filename)
-    samples = fp.getnframes()
-    sampling_rate = fp.getframerate()
-    channels = fp.getnchannels()
-    audio = fp.readframes(samples)
+    #we use librosa because it supports more codecs and is less likely to crash on an unsual encoding
+    y,sr = librosa.load(filename, sr=None,mono=False, offset=start_s, duration = length_s)
+    channels = 1 if len(y.shape) == 1 else y.shape[0]
 
-    audio_as_np_int16 = np.frombuffer(audio, dtype=np.int16, offset = int(start_s*sampling_rate*channels), count=int(length_s*sampling_rate*channels))
-    audio_as_np_float32 = audio_as_np_int16.astype(np.float32)
-    
-    max_int16 = 2**15
-    audio_normalised = audio_as_np_float32 / max_int16
-
-    return audio_normalised, sampling_rate, channels
+    return y, sr, channels
 
 #computes a list of similarity scores, each value being for 1 frame of audio
 #returns the most differing value
@@ -85,43 +77,45 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
     ref, ref_rate, ref_chan = read_wav(file1, start1, interval)
     test, test_rate, test_chan = read_wav(file2, start2, interval)
 
+    #when sampling rate is different, look for a downsampled rate that can be used
     if ref_rate != test_rate:
-        raise Exception('audios do not match, their sampling rate is :\n{} : {}\n{} : {}'.format(file1,ref_rate,file2,test_rate))
+        from math import gcd
+        new_rate = gcd(ref_rate,test_rate)
+        print('WARNING : sampling rates do not match between audios ({}Hz and {}Hz), attempting to downsample to {}Hz'.format(ref_rate,test_rate,new_rate))
+        if ref_rate > new_rate : #downsample if needed
+            ref = ref[::int(ref_rate/new_rate)]
+            ref_rate = new_rate
+        if test_rate > new_rate : #downsample if needed
+            test = test[::int(test_rate/new_rate)]
+            test_rate = new_rate
         
-    if ref_chan != test_chan:
+    if ref_chan != test_chan: #if different number of channels, shrink if possible
         print('WARNING : different number of channels, attempting to compress channels to carry on with correlation analysis while reducing information on the higher channel file')
-        if ref_chan == 1 and test_chan == 2:
-            test = np.reshape(test,(int(len(test)/2),2))
-            test = np.mean(test,axis=1)
+        if ref_chan == 1 and test_chan > 1 :
+            test = np.mean(test,axis=0)
+            test_chan = 1
             print('{} was shrunk to mono channel for the analysis, it has a higher level of information than {}'.format(file2,file1))
-        elif ref_chan == 2 and test_chan == 1:
-            ref = np.reshape(ref,(int(len(ref)/2),2))
-            ref = np.mean(ref,axis=1)
+        elif ref_chan > 1 and test_chan == 1:
+            ref = np.mean(ref,axis=0)
+            ref_chan = 1
             print('{} was shrunk to mono channel for the analysis, it has a higher level of information than {}'.format(file1,file2))
         else:
             raise Exception('audios do not match, {} has {} channel(s) while {} has {}'.format(file1,ref_chan,file2,test_chan))
+        
+    #in case of multiple channels, reshape to be 1D array (they should have the same number of channels at this point)
+    if ref_chan > 1:
+        np.reshape(ref,ref_chan * ref.shape[1])
+        np.reshape(test,test_chan * test.shape[1])
 
     sampling_rate = ref_rate
 
+    #downsample to save computation time
     downsampled_rate = 400
     ref = ref[::int(sampling_rate/downsampled_rate)]
     test = test[::int(sampling_rate/downsampled_rate)]
+    
+    # straight up difference of the audio signal averaged over the 2 segments analysed
+    # times 1000 is arbitrary, just to have an easily readable and comparable score output
+    res = np.abs(ref - test).sum() * 1000 /(len(ref))
 
-    ref_padded = np.concatenate((np.zeros(len(ref)-1), ref))
-    test_padded = np.concatenate((test, np.zeros(len(ref)-len(test)+len(ref)-1)))
-
-    ref_fft = fft(ref_padded)
-    test_fft = fft(test_padded)
-
-    cross_spectral_density = ref_fft*np.conj(test_fft)
-    cross_correlations = ifft(cross_spectral_density)
-
-    mag_cross_correlations = np.abs(cross_correlations)
-
-    if correlation_output:
-        np.savetxt(correlation_output, mag_cross_correlations, delimiter = ' ')
-
-    #take the highest differing frame score
-    shift = np.argmax(mag_cross_correlations) - max(len(ref),len(test))
-
-    return shift/downsampled_rate
+    return res,len(ref)

--- a/docs/source/ChildProject.rst
+++ b/docs/source/ChildProject.rst
@@ -30,7 +30,7 @@ ChildProject.cmdline module
    :show-inheritance:
 
 ChildProject.converters module
----------------------------
+------------------------------
 
 .. automodule:: ChildProject.converters
    :members:

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -123,9 +123,9 @@ in a separate file.
 .. warning::
 
    For recursive metadata, two dataframes cannot share the same basename.
-   For instance, if one dataframe is located at `metadata/children/dates-of-birth.csv`,
+   For instance, if one dataframe is located at `metadata/children/dates-of-birth.csv` ,
    an error will be thrown if another dataframe exists at
-   `metadata/children/private/dates-of-birth.csv `.
+   `metadata/children/private/dates-of-birth.csv ` .
 
 Annotations
 -----------
@@ -162,7 +162,7 @@ Annotations index
     The index is maintained through the package functions only; it should never be updated by hand.
 
 Annotations are indexed in one unique dataframe located at
-``/metadata/annotations.csv``, with the following format :
+``/metadata/annotations.csv`` , with the following format :
 
 .. index-table:: Annotations metadata
    :header: annotations
@@ -243,9 +243,9 @@ to the following table:
 .. comment::
     This comment fixes an issue introduced in Sphinx 4.3.1
 
- - Documentation for the children metadata should be stored in ``docs/children.csv``
- - Documentation for the recordings metadata should be stored in ``docs/recordings.csv``
- - Documentation for annotations should be stored in ``docs/annotations.csv``
+- Documentation for the children metadata should be stored in ``docs/children.csv``
+- Documentation for the recordings metadata should be stored in ``docs/recordings.csv``
+- Documentation for annotations should be stored in ``docs/annotations.csv``
 
 Authorship
 ~~~~~~~~~~

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,5 +1,5 @@
 Metrics extraction
-----------------
+------------------
 
 Overview
 ~~~~~~~~
@@ -57,7 +57,7 @@ LENA Metrics
    child-project metrics /path/to/dataset output.csv lena --help
 
 ACLEW Metrics
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. clidoc::
 

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -90,4 +90,4 @@ Giving a higher `--interval` value may take more time to compute.
 
 .. clidoc::
 
-   child-project correlate-audio /path/to/dataset --help
+   child-project compare-recordings /path/to/dataset --help

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -78,7 +78,7 @@ in the metadata.
    child-project compute-durations /path/to/dataset --help
 
 Compute the correlation between audio files
----------------------------
+-------------------------------------------
 
 Compute the correlation between two audio files and prints a divergence score.
 The divergence is computed over a given duration (default 5min) that can be changed with the `--interval` option.
@@ -86,7 +86,7 @@ One segment of that duration is taken randomly, the difference in audio signal i
 The closer the score is to 0, the more likely it is the 2 files are identical. We can consider that scores below 0.1 reflect a very high probability that the files are the same. At the other end of the spectrum, values higher than 1 almost certainly means they are different recordings.
 So a window exists in which we can't be sure and would need additional correlation computations or manual checks. Running the correlation multiple time is useful because files that are different have a high variability in score whereas similar files will have a much more consistent output.
 
-Giving a higher `-- interval` value may take more time to compute.
+Giving a higher `--interval` value may take more time to compute.
 
 .. clidoc::
 

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -76,3 +76,18 @@ in the metadata.
 .. clidoc::
 
    child-project compute-durations /path/to/dataset --help
+
+Compute the correlation between audio files
+---------------------------
+
+Compute the correlation between two audio files and prints a similarity score.
+The similarity is evaluated over a given duration (default 5min) that can be changed with the `--interval` option.
+One segment of that duration taken randomly in the recordings total duration is evluated and a similarity score is computed for every frame of that segment. Then only the highest score is kept (meaning the frame where the 2 files differed the most) and is printed.
+The closer the score is to 0, the more likely it is the 2 files are identical. We can consider that scores below <VALUE>(0.01?) reflect a very high probability that the files are the same. At the other end of the spectrum, values higher than <VALUE>(0?) almost certainly means they are different.
+So a window exists in which we can't be sure and would need additional correlation computations or manual checks.
+
+Giving a higher `-- interval` value may take more time to compute and will yield higher scores on average just because the sample is bigger, but it should be more reliable.
+
+.. clidoc::
+
+   child-project correlate-audio /path/to/dataset --help

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -80,13 +80,13 @@ in the metadata.
 Compute the correlation between audio files
 ---------------------------
 
-Compute the correlation between two audio files and prints a similarity score.
-The similarity is evaluated over a given duration (default 5min) that can be changed with the `--interval` option.
-One segment of that duration taken randomly in the recordings total duration is evluated and a similarity score is computed for every frame of that segment. Then only the highest score is kept (meaning the frame where the 2 files differed the most) and is printed.
-The closer the score is to 0, the more likely it is the 2 files are identical. We can consider that scores below <VALUE>(0.01?) reflect a very high probability that the files are the same. At the other end of the spectrum, values higher than <VALUE>(0?) almost certainly means they are different.
-So a window exists in which we can't be sure and would need additional correlation computations or manual checks.
+Compute the correlation between two audio files and prints a divergence score.
+The divergence is computed over a given duration (default 5min) that can be changed with the `--interval` option.
+One segment of that duration is taken randomly, the difference in audio signal is calculated and averaged over the total duration. The result is printed as a divergence score.
+The closer the score is to 0, the more likely it is the 2 files are identical. We can consider that scores below 0.1 reflect a very high probability that the files are the same. At the other end of the spectrum, values higher than 1 almost certainly means they are different recordings.
+So a window exists in which we can't be sure and would need additional correlation computations or manual checks. Running the correlation multiple time is useful because files that are different have a high variability in score whereas similar files will have a much more consistent output.
 
-Giving a higher `-- interval` value may take more time to compute and will yield higher scores on average just because the sample is bigger, but it should be more reliable.
+Giving a higher `-- interval` value may take more time to compute.
 
 .. clidoc::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pysoundfile
 python-dateutil>=2.8.1
 PyYAML
 requests==2.25.0
+scipy
 sklearn
 sox
 sphinx

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,3 +64,17 @@ def test_explain():
         ]
     )
     assert exit_code == 0
+    
+def test_correlate_audio():
+    stdout, stderr, exit_code = cli(
+        [
+            "child-project",
+            "correlate-audio",
+            "examples/valid_raw_data",
+            "sound.wav",
+            "sound2.wav",
+            "--interval",
+            "10"
+        ]
+    )
+    assert exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,11 +65,11 @@ def test_explain():
     )
     assert exit_code == 0
     
-def test_correlate_audio():
+def test_compare_recordings():
     stdout, stderr, exit_code = cli(
         [
             "child-project",
-            "correlate-audio",
+            "compare-recordings",
             "examples/valid_raw_data",
             "sound.wav",
             "sound2.wav",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,7 +6,7 @@ def test_valid_project():
     errors, warnings = project.validate()
 
     assert len(errors) == 0, "valid input validation failed (expected to pass)"
-    assert len(warnings) == 1, "expected 1 warning, got {}".format(len(warnings))
+    assert len(warnings) == 3, "expected 1 warning, got {}".format(len(warnings))
 
 
 def test_invalid_project():


### PR DESCRIPTION
- New command : 
`child-project compare-recordings <path> <audio1> <audio2> [--interval n] [--profile <profile>`
Outputs a divergence score meant to help identify whether 2 recordings are the same (or derived from one another)

- Improvement
`child-project validate` : 
Now issues warnings if raw recordings are not 16kHz **and** `converted/standard` is not as well.

- [x] documentation