### PR TITLE
Projects/time support seconds

### DIFF
--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -162,17 +162,17 @@ class Metrics(ABC):
         
         if from_time:
             try:
-                self.from_time = datetime.datetime.strptime(from_time, "%H:%M")
+                self.from_time = datetime.datetime.strptime(from_time, "%H:%M:%S")
             except:
-                raise ValueError(f"invalid value for from_time ('{from_time}'); should have HH:MM format instead")
+                raise ValueError(f"invalid value for from_time ('{from_time}'); should have HH:MM:SS format instead")
         else:
             self.from_time = None
         
         if to_time:
             try:
-                self.to_time = datetime.datetime.strptime(to_time, "%H:%M")
+                self.to_time = datetime.datetime.strptime(to_time, "%H:%M:%S")
             except:
-                raise ValueError(f"invalid value for to_time ('{to_time}'); should have HH:MM format instead")
+                raise ValueError(f"invalid value for to_time ('{to_time}'); should have HH:MM:SS format instead")
         else:
             self.to_time = None
         
@@ -692,14 +692,14 @@ class MetricsPipeline(Pipeline):
         parser.add_argument(
             "-f",
             "--from-time",
-            help="time range start in HH:MM format (optional)",
+            help="time range start in HH:MM:SS format (optional)",
             default=None,
         )
 
         parser.add_argument(
             "-t",
             "--to-time",
-            help="time range end in HH:MM format (optional)",
+            help="time range end in HH:MM:SS format (optional)",
             default=None,
         )
         

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -58,7 +58,7 @@ class ChildProject:
             name="child_dob",
             description="child's date of birth",
             required=True,
-            datetime="%Y-%m-%d",
+            datetime={"%Y-%m-%d"},
         ),
         IndexColumn(
             name="location_id",
@@ -156,13 +156,13 @@ class ChildProject:
             name="date_iso",
             description="date in which recording was started in ISO (eg 2020-09-17)",
             required=True,
-            datetime="%Y-%m-%d",
+            datetime={"%Y-%m-%d"},
         ),
         IndexColumn(
             name="start_time",
-            description="local time in which recording was started in format 24-hour (H)H:MM; if minutes are unknown, use 00. ‘NA’ if unknown, this will raise a Warning when validating.",
+            description="local time in which recording was started in format 24-hour (H)H:MM:SS or (H)H:MM; if minutes or seconds are unknown, use 00. ‘NA’ if unknown, this will raise a Warning when validating as some analysis that rely on times will not consider this recordings.",
             required=True,
-            datetime="%H:%M",
+            datetime={"%H:%M","%H:%M:%S"},
         ),
         IndexColumn(
             name="recording_device_type",
@@ -220,8 +220,8 @@ class ChildProject:
         ),
         IndexColumn(
             name="start_time_accuracy",
-            description="Accuracy of start_time for this recording. If not specified, assumes minute-accuray.",
-            choices=["minute", "hour", "reliable"],
+            description="Accuracy of start_time for this recording. If not specified, assumes second-accuray.",
+            choices=["second", "minute", "hour", "reliable"],
         ),
         IndexColumn(
             name="noisy_setting",

--- a/ChildProject/tables.py
+++ b/ChildProject/tables.py
@@ -200,10 +200,10 @@ class IndexTable:
 
                 elif column_attr.datetime:
                     passed = False
-                    for i in column_attr.datetime:
+                    for frmt in column_attr.datetime:
                         try:
                             dt = datetime.datetime.strptime(
-                                row[column_name], column_attr.datetime
+                                row[column_name], frmt
                             )
                             passed = True
                             break

--- a/ChildProject/tables.py
+++ b/ChildProject/tables.py
@@ -199,15 +199,21 @@ class IndexTable:
                         warnings.append(self.msg(message))
 
                 elif column_attr.datetime:
-                    try:
-                        dt = datetime.datetime.strptime(
-                            row[column_name], column_attr.datetime
-                        )
-                    except:
-                        message = "'{}' is not a proper date/time for column '{}' (expected {}) on line {}".format(
+                    passed = False
+                    for i in column_attr.datetime:
+                        try:
+                            dt = datetime.datetime.strptime(
+                                row[column_name], column_attr.datetime
+                            )
+                            passed = True
+                            break
+                        except:
+                            pass
+                    if not passed:
+                        message = "'{}' is not a proper date/time for column '{}' (expected: {}) on line {}".format(
                             row[column_name],
                             column_name,
-                            column_attr.datetime,
+                            ' / '.join(column_attr.datetime),
                             line_number,
                         )
                         if column_attr.required and str(row[column_name]) != "NA":

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -62,6 +62,9 @@ class TimeInterval:
     def __repr__(self):
         return "TimeInterval([{}, {}])".format(self.start, self.stop)
     
+    def __eq__(self, other):
+        return self.start == other.start and self.stop == other.stop
+    
 def time_intervals_intersect(ti1 : TimeInterval, ti2 : TimeInterval):
     """
     given 2 time intervals (those do not take in consideration days, only time in the day), return an array of new interval(s) representing the intersections of the original ones.
@@ -186,6 +189,8 @@ def series_to_datetime(time_series, time_index_list, time_column_name:str, date_
     :type date_index_list: List[IndexColumn]
     :param date_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats for dates
     :type date_column_name: str
+    :return: series with dtype datetime containing the converted datetimes
+    :rtype: pandas.Series
     """
     time_formats = next(x for x in time_index_list if x.name==time_column_name).datetime
     series = pd.Series(np.nan, index=np.arange(time_series.shape[0]) , dtype='datetime64[ns]')

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -167,34 +167,37 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
 
     return res,len(ref)
 
-    def series_to_datetime(time_series, time_index_list, time_column_name:str, date_series = None, date_index_list = None, date_column_name = None):
-        """
-        returns a series of datetimes from a series of str. Using pd.to_datetime on all the formats listed for a specific column name in an index consisting of IndexColumn items. To have the date included and not only time), one can use a second series for date, with also the corresponding index and column
-        
-        :param time_series: pandas series of strings to transform into datetime (can contain NA value => NaT datetime), if date_series is given, time_series should only have the time
-        :type time_series: pandas.Series
-        :param time_index_list: list of index to use where the column wanted is present
-        :type time_index_list: List[IndexColumn]
-        :param time_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats
-        :type time_column_name: str
-        :param date_series: pandas series of strings to transform into the date component of datetime (can contain NA value)
-        :type date_series: pandas.Series
-        :param date_index_list: list of index to use where the column wanted is present
-        :type date_index_list: List[IndexColumn]
-        :param date_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats for dates
-        :type date_column_name: str
-        """
-        time_formats = next(x for x in time_index_list if x.name==time_column_name).datetime
-        series = pd.Series(np.nan, index=time_series.shape[0] , dtype='datetime64[ns]')
-        if date_series:
-            time_sr = time_series + ' ' + date_series
-            date_formats = next(x for x in date_index_list if x.name==date_column_name).datetime
-            for frmt in time_formats:
-                for dfrmt in date_formats:
-                    series = series.fillna(pd.to_datetime(time_sr, format="{} {}".format(dfrmt,frmt), errors="coerce"))
-        else:
-            time_sr = series.copy()
-            for frmt in time_formats:
-                series = series.fillna(pd.to_datetime(time_sr, format=frmt, errors="coerce"))
-        return series
+def series_to_datetime(time_series, time_index_list, time_column_name:str, date_series = None, date_index_list = None, date_column_name = None):
+    """
+    returns a series of datetimes from a series of str. Using pd.to_datetime on all the formats \
+    listed for a specific column name in an index consisting of IndexColumn items. \
+    To have the date included and not only time), one can use a second series for date, \
+    with also the corresponding index and column
+    
+    :param time_series: pandas series of strings to transform into datetime (can contain NA value => NaT datetime), if date_series is given, time_series should only have the time
+    :type time_series: pandas.Series
+    :param time_index_list: list of index to use where the column wanted is present
+    :type time_index_list: List[IndexColumn]
+    :param time_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats
+    :type time_column_name: str
+    :param date_series: pandas series of strings to transform into the date component of datetime (can contain NA value)
+    :type date_series: pandas.Series
+    :param date_index_list: list of index to use where the column wanted is present
+    :type date_index_list: List[IndexColumn]
+    :param date_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats for dates
+    :type date_column_name: str
+    """
+    time_formats = next(x for x in time_index_list if x.name==time_column_name).datetime
+    series = pd.Series(np.nan, index=time_series.shape[0] , dtype='datetime64[ns]')
+    if date_series:
+        time_sr = time_series + ' ' + date_series
+        date_formats = next(x for x in date_index_list if x.name==date_column_name).datetime
+        for frmt in time_formats:
+            for dfrmt in date_formats:
+                series = series.fillna(pd.to_datetime(time_sr, format="{} {}".format(dfrmt,frmt), errors="coerce"))
+    else:
+        time_sr = series.copy()
+        for frmt in time_formats:
+            series = series.fillna(pd.to_datetime(time_sr, format=frmt, errors="coerce"))
+    return series
     

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import librosa
 from scipy.fftpack import fft, ifft
 import numpy as np
+import pandas as pd
 
 def path_is_parent(parent_path: str, child_path: str):
     # Smooth out relative path names, note: if you are concerned about symbolic links, you should use os.path.realpath too
@@ -165,3 +166,35 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
     res = np.abs(ref - test).sum() * 1000 /(len(ref))
 
     return res,len(ref)
+
+    def series_to_datetime(time_series, time_index_list, time_column_name:str, date_series = None, date_index_list = None, date_column_name = None):
+        """
+        returns a series of datetimes from a series of str. Using pd.to_datetime on all the formats listed for a specific column name in an index consisting of IndexColumn items. To have the date included and not only time), one can use a second series for date, with also the corresponding index and column
+        
+        :param time_series: pandas series of strings to transform into datetime (can contain NA value => NaT datetime), if date_series is given, time_series should only have the time
+        :type time_series: pandas.Series
+        :param time_index_list: list of index to use where the column wanted is present
+        :type time_index_list: List[IndexColumn]
+        :param time_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats
+        :type time_column_name: str
+        :param date_series: pandas series of strings to transform into the date component of datetime (can contain NA value)
+        :type date_series: pandas.Series
+        :param date_index_list: list of index to use where the column wanted is present
+        :type date_index_list: List[IndexColumn]
+        :param date_column_name: name of the IndexColumn to use (IndexColumn.name value) for accepted formats for dates
+        :type date_column_name: str
+        """
+        time_formats = next(x for x in time_index_list if x.name==time_column_name).datetime
+        series = pd.Series(np.nan, index=time_series.shape[0] , dtype='datetime64[ns]')
+        if date_series:
+            time_sr = time_series + ' ' + date_series
+            date_formats = next(x for x in date_index_list if x.name==date_column_name).datetime
+            for frmt in time_formats:
+                for dfrmt in date_formats:
+                    series = series.fillna(pd.to_datetime(time_sr, format="{} {}".format(dfrmt,frmt), errors="coerce"))
+        else:
+            time_sr = series.copy()
+            for frmt in time_formats:
+                series = series.fillna(pd.to_datetime(time_sr, format=frmt, errors="coerce"))
+        return series
+    

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -188,15 +188,15 @@ def series_to_datetime(time_series, time_index_list, time_column_name:str, date_
     :type date_column_name: str
     """
     time_formats = next(x for x in time_index_list if x.name==time_column_name).datetime
-    series = pd.Series(np.nan, index=time_series.shape[0] , dtype='datetime64[ns]')
-    if date_series:
-        time_sr = time_series + ' ' + date_series
+    series = pd.Series(np.nan, index=np.arange(time_series.shape[0]) , dtype='datetime64[ns]')
+    if date_series is not None:
+        time_sr = date_series + ' ' + time_series
         date_formats = next(x for x in date_index_list if x.name==date_column_name).datetime
         for frmt in time_formats:
             for dfrmt in date_formats:
                 series = series.fillna(pd.to_datetime(time_sr, format="{} {}".format(dfrmt,frmt), errors="coerce"))
     else:
-        time_sr = series.copy()
+        time_sr = time_series.copy()
         for frmt in time_formats:
             series = series.fillna(pd.to_datetime(time_sr, format=frmt, errors="coerce"))
     return series

--- a/docs/source/_ext/directives.py
+++ b/docs/source/_ext/directives.py
@@ -76,7 +76,7 @@ class IndexTable(CSVTable):
 
             df_entry['Format'] = ''
             if column.datetime:
-                df_entry['Format'] = "``{}``".format(column.datetime)
+                df_entry['Format'] = "``{}``".format(' / '.join(column.datetime))
             elif column.regex:
                 df_entry['Format'] = "``{}``".format(column.regex)
             elif column.function:

--- a/tests/data/parameters_metrics.yml
+++ b/tests/data/parameters_metrics.yml
@@ -4,8 +4,8 @@ path : output/metrics
 destination : output/metrics/extra/specs_metrics.csv
 child_cols : child_dob,experiment
 rec_cols : date_iso
-from_time : "8:15"
-to_time : "16:45"
+from_time : "8:15:00"
+to_time : "16:45:00"
 period : 2h
 metrics_list :
  -

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -99,7 +99,7 @@ def test_lena(project):
         import_function=partial(fake_vocs, data),
     )
 
-    lena = LenaMetrics(project, set="lena_its", period='1h', from_time='10:00' , to_time= '16:00')
+    lena = LenaMetrics(project, set="lena_its", period='1h', from_time='10:00:00' , to_time= '16:00:00')
     lena.extract()
 
     truth = pd.read_csv("tests/truth/lena_metrics.csv")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 27 11:23:05 2022
+
+@author: lpeurey
+"""
+from ChildProject.projects import ChildProject
+from ChildProject.utils import series_to_datetime, time_intervals_intersect, intersect_ranges, TimeInterval
+import pandas as pd
+import datetime
+
+def test_series_to_datetime():
+    project = ChildProject("examples/valid_raw_data")
+    
+    only_time = pd.Series(['3:12','04:14', '12:19:21', '32:77'])
+    only_date = pd.Series(['2022-01-23','2022-01-23', '2022-01-23', '2022-01-23'])
+    
+    truth = pd.Series([datetime.datetime(1900,1,1,3,12,0,0),
+                       datetime.datetime(1900,1,1,4,14,0,0),
+                       datetime.datetime(1900,1,1,12,19,21,0),
+                       pd.NaT,
+                       ])
+    
+    #convert to datetime using the formats for start_time listed in the project RECORDINGS_COLUMNS.Index(name == 'start_time')
+    converted_time = series_to_datetime(only_time, project.RECORDINGS_COLUMNS, 'start_time')
+    
+    pd.testing.assert_series_equal(converted_time, truth)
+    
+    truth = pd.Series([datetime.datetime(2022,1,23,3,12,0,0),
+                       datetime.datetime(2022,1,23,4,14,0,0),
+                       datetime.datetime(2022,1,23,12,19,21,0),
+                       pd.NaT,
+                       ])
+    
+    #convert to datetime using the formats for start_time and date_iso listed in the project RECORDINGS_COLUMNS.Index(name == 'start_time') and Index(name == 'date_iso')
+    converted_time = series_to_datetime(only_time, project.RECORDINGS_COLUMNS, 'start_time', only_date, project.RECORDINGS_COLUMNS, 'date_iso')
+    
+    pd.testing.assert_series_equal(converted_time, truth)
+    
+def test_time_intervals_intersect():
+    truth = [TimeInterval(datetime.datetime(1900,1,1,10,36),datetime.datetime(1900,1,1,21,4))]
+    res = time_intervals_intersect(TimeInterval(datetime.datetime(1900,1,1,8,57),datetime.datetime(1900,1,1,21,4)),TimeInterval(datetime.datetime(1900,1,1,10,36),datetime.datetime(1900,1,1,22,1)))
+    
+    for i in range(len(truth)):
+        assert truth[i] == res[i] 
+    
+    truth = [TimeInterval(datetime.datetime(1900,1,1,8,57),datetime.datetime(1900,1,1,10,36)),TimeInterval(datetime.datetime(1900,1,1,21,4),datetime.datetime(1900,1,1,22,1))]
+    res = time_intervals_intersect(TimeInterval(datetime.datetime(1900,1,1,8,57),datetime.datetime(1900,1,1,22,1)),TimeInterval(datetime.datetime(1900,1,1,21,4),datetime.datetime(1900,1,1,10,36)))
+    
+    for i in range(len(truth)):
+        assert truth[i] == res[i]
+    
+    truth = [TimeInterval(datetime.datetime(1900,1,1,21,4),datetime.datetime(1900,1,1,3,1))]
+    res = time_intervals_intersect(TimeInterval(datetime.datetime(1900,1,1,8,57),datetime.datetime(1900,1,1,3,1)),TimeInterval(datetime.datetime(1900,1,1,21,4),datetime.datetime(1900,1,1,7,36)))
+    
+    for i in range(len(truth)):
+        assert truth[i] == res[i]
+        


### PR DESCRIPTION
- Start times can include seconds (e.g. 12:34:59) while still accepting the old format (This change will allow other columns to accept multiple formats easily).
- `metrics` pipeline's options `--from --to` require a HH:MM:SS format now.