### PR TITLE
let merge fail on existing output_set or unexisting left/right_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `metrics` pipeline's options `--from --to` require a HH:MM:SS format now.
+- `merge-annotations` command fails when the output_set already exists or if the required sets don't exist
 
 ## [0.0.5] - 2022-07-25
 

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -872,7 +872,8 @@ class AnnotationManager:
     ):
         """Merge columns from ``left_set`` and ``right_set`` annotations, 
         for all matching segments, into a new set of annotations named
-        ``output_set``.
+        ``output_set`` that will be saved in the dataset. ``output_set``
+        must not already exist. 
 
         :param left_set: Left set of annotations.
         :type left_set: str
@@ -887,6 +888,10 @@ class AnnotationManager:
         :return: [description]
         :rtype: [type]
         """
+        existing_sets = self.annotations['set'].unique()
+        assert output_set not in existing_sets, "output_set <{}> already exists, remove the existing set or choose an other name.".format(output_set)
+        assert left_set in existing_sets, "left_set <{}> was not found, check the spelling.".format(left_set)
+        assert right_set in existing_sets, "right_set <{}> was not found, check the spelling.".format(right_set)
         assert left_set != right_set, "sets must differ"
         assert not (
             set(left_columns) & set(right_columns)


### PR DESCRIPTION
- Merge_sets requires that the output_set does not already exist. This will force the user to remove the existing set before rerunning the merge
- Merge_sets checks that left/right_set exist

see #384 