### PR TITLE
eafBuilder, default tier type for ChildProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - `metrics` pipeline's options `--from --to` require a HH:MM:SS format now.
 
+### Fixed
+
+- eafbuilder attributes a default time-aligneable ling-type to created tiers to avoid random attribution that can lead to wrong behaviour and crashes
+
 ## [0.0.5] - 2022-07-25
 
 ### Added

--- a/ChildProject/pipelines/eafbuilder.py
+++ b/ChildProject/pipelines/eafbuilder.py
@@ -11,6 +11,7 @@ from ChildProject.tables import assert_dataframe, assert_columns_presence
 from ChildProject.converters import Formats
 
 FORMAT_SPEECH = {Formats.VTC.value,Formats.VCM.value} #formats for which nan must be replaced with SPEECH
+CHILDPROJECT_TYPE = "childProject_generated"
 
 def create_eaf(
     etf_path: str,
@@ -29,17 +30,14 @@ def create_eaf(
     import pympi
 
     eaf = pympi.Elan.Eaf(etf_path)
-
-    ling_type = "transcription"
-    """
-    eaf.add_tier("code_" + eaf_type, ling=ling_type)
-    eaf.add_tier("context_" + eaf_type, ling=ling_type)
-    eaf.add_tier("code_num_" + eaf_type, ling=ling_type)
-    """
-    eaf.add_tier("SAMPLER", ling=ling_type)
-    eaf.add_tier("code_" + eaf_type, ling=ling_type, parent="SAMPLER")
-    eaf.add_tier("context_" + eaf_type, ling=ling_type, parent="SAMPLER")
-    eaf.add_tier("code_num_" + eaf_type, ling=ling_type, parent="SAMPLER")
+    
+    #create a default ling_type for generated tiers to be always time-aligneable
+    eaf.add_linguistic_type(CHILDPROJECT_TYPE, timealignable=True)
+    
+    eaf.add_tier("SAMPLER", ling=CHILDPROJECT_TYPE)
+    eaf.add_tier("code_" + eaf_type, ling=CHILDPROJECT_TYPE, parent="SAMPLER")
+    eaf.add_tier("context_" + eaf_type, ling=CHILDPROJECT_TYPE, parent="SAMPLER")
+    eaf.add_tier("code_num_" + eaf_type, ling=CHILDPROJECT_TYPE, parent="SAMPLER")
 
     for i, ts in enumerate(timestamps_list):
         print("Creating eaf code segment # ", i + 1)
@@ -79,7 +77,7 @@ def create_eaf(
             if imported_set: speaker_id = "{}-{}".format(imported_set.replace("/","_").upper(),speaker_id)
 
             if speaker_id not in eaf.tiers:
-                eaf.add_tier(speaker_id)
+                eaf.add_tier(speaker_id, ling=CHILDPROJECT_TYPE)
 
             eaf.add_annotation(
                 speaker_id,


### PR DESCRIPTION
When creating a pre-filled EAF (e.g. with VTC annotations) when using a user-defined template, the tier type 'transcription' might not exist in the EAF.

Creating a new default linguistic_type that is timealignable for all ChildProject tiers.

see #382 
