### PR TITLE
Processors/drop split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - `metrics` pipeline's options `--from --to` require a HH:MM:SS format now.
 
+### Dropped
+
+- `child-project process --split` --split option dropped as there is no further need of reducing long audios (>15hs)
+
 ## [0.0.5] - 2022-07-25
 
 ### Added


### PR DESCRIPTION
see #320 

drop the --split option in the processor pipeline as there are no reason to keep splitting long audios as all the software used is now able to handle those large files. Splitting adds unnecessary complexity.