### PR TITLE
do not priorityze vcm_type for metrics when other available (lena)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - eafbuilder attributes a default time-aligneable ling-type to created tiers to avoid random attribution that can lead to wrong behaviour and crashes
 - 'imported_at' column in annotations.csv did not have a new correct format (in a set)
 - metrics avg_cry_... avg_can_... and avg_non_can_... were not calculated correctly
+- metrics lp_n lp_dur use lena columns in priority
 
 ### Dropped
 

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -223,15 +223,7 @@ def lp_n(annotations: pd.DataFrame, duration: int, **kwargs):
     
     Required keyword arguments:
     """
-    if "vcm_type" in annotations.columns:
-        speech_voc = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"].isin(["N","C"]))].shape[0]
-        cry_voc = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"]== "Y")].shape[0]
-        total = speech_voc + cry_voc
-        if total:
-            value = speech_voc / total
-        else:
-            value = np.nan
-    elif set(["cries","vfxs","utterances_count"]).issubset(annotations.columns):
+    if set(["cries","vfxs","utterances_count"]).issubset(annotations.columns):
         annotations = annotations[annotations["speaker_type"] == "CHI"]
         cries = annotations["cries"].apply(lambda x: len(ast.literal_eval(x))).sum()
         vfxs = annotations["vfxs"].apply(lambda x: len(ast.literal_eval(x))).sum()
@@ -239,6 +231,14 @@ def lp_n(annotations: pd.DataFrame, duration: int, **kwargs):
         total = (utterances + cries + vfxs)
         if total:
             value = utterances / total
+        else:
+            value = np.nan
+    elif "vcm_type" in annotations.columns:
+        speech_voc = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"].isin(["N","C"]))].shape[0]
+        cry_voc = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"]== "Y")].shape[0]
+        total = speech_voc + cry_voc
+        if total:
+            value = speech_voc / total
         else:
             value = np.nan
     else:
@@ -265,20 +265,20 @@ def lp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
     
     Required keyword arguments:
     """
-    if "vcm_type" in annotations.columns:
-        speech_dur = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"].isin(["N","C"]))]["duration"].sum()
-        cry_dur = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"]== "Y")]["duration"].sum()
-        total = speech_dur + cry_dur
-        if total:
-            value = speech_dur / total
-        else:
-            value = np.nan
-    elif set(["child_cry_vfx_len","utterances_length"]).issubset(annotations.columns):
+    if set(["child_cry_vfx_len","utterances_length"]).issubset(annotations.columns):
         annotations = annotations[annotations["speaker_type"] == "CHI"]
         utter_len = annotations["utterances_length"].sum()
         total = annotations["child_cry_vfx_len"].sum() + utter_len
         if total:
             value = utter_len / total
+        else:
+            value = np.nan
+    elif "vcm_type" in annotations.columns:
+        speech_dur = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"].isin(["N","C"]))]["duration"].sum()
+        cry_dur = annotations.loc[(annotations["speaker_type"]== "CHI") & (annotations["vcm_type"]== "Y")]["duration"].sum()
+        total = speech_dur + cry_dur
+        if total:
+            value = speech_dur / total
         else:
             value = np.nan
     else:


### PR DESCRIPTION
metrics:
- lp_n
- lp_dur
can be computed using lena columns (utterances/utterances_length/vfxs etc.) or with the 'vcm_type' column.
Problem : vcm_type can be NA when derived from lena but the linguistic info exists in lena form. The metrics functions are first checking for the presence of vcm_type and use it, they should use lena's column in priority.