### PR TITLE
Metrics/segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Start times can include seconds (e.g. 12:34:59) while still accepting the old format (This change will allow other columns to accept multiple formats easily).
 - `child-project --version` command
+- `child-project metrics` added the `--segments` command to extract metrics from a dataFrame of segments
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Start times can include seconds (e.g. 12:34:59) while still accepting the old format (This change will allow other columns to accept multiple formats easily).
 - `child-project --version` command
 - `child-project metrics` added the `--segments` command to extract metrics from a dataFrame of segments
+- metrics <voc_speaker> and <lena_CVC>
 
 ### Changed
 

--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -27,7 +27,7 @@ class Metrics(ABC):
     :type project: ChildProject.projects.ChildProject
     :param metrics_list: pandas DataFrame containing the desired metrics (metrics functions are in metricsFunctions.py)
     :type metrics_list: pd.DataFrame
-    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', use 'segments' to use the segments argument
+    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', 'segments' is mandatory if passing the segments argument
     :type by: str, optional
     :param recordings: recordings to sample from; if None, all recordings will be sampled, defaults to None
     :type recordings: Union[str, List[str], pd.DataFrame], optional
@@ -41,7 +41,7 @@ class Metrics(ABC):
     :type child_cols: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
-    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the option must be set to 'segments'. Also, this option cannot be combined with options [recordings,period,from_time,to_time].
     :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
@@ -153,7 +153,7 @@ class Metrics(ABC):
         self.recordings = Pipeline.recordings_from_list(recordings)
         
         if segments is not None:
-            assert by == 'segments' and period is None and recordings is None and from_time is None and to_time is None, "the <segments> option can not be used with options [period,recordings,from_time,to_time], and <by> should be set to 'segments'"
+            assert by == 'segments' and period is None and recordings is None and from_time is None and to_time is None, "the <segments> option can not be combined with options [period,recordings,from_time,to_time], and <by> should be set to 'segments'"
             if isinstance(segments, pd.DataFrame):
                 self.segments = segments
             else:
@@ -396,11 +396,11 @@ class CustomMetrics(Metrics):
     :type rec_cols: str, optional
     :param child_cols: comma separated columns from children.csv to include in the outputted metrics (optional), None by default
     :type child_cols: str, optional
-    :param by: units to sample from, defaults to 'recording_filename', use 'segments' to use the segments argument
+    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', 'segments' is mandatory if passing the segments argument
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
-    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the option must be set to 'segments'. Also, this option cannot be combined with options [recordings,period,from_time,to_time].
     :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
@@ -454,11 +454,11 @@ class LenaMetrics(Metrics):
     :type rec_cols: str, optional
     :param child_cols: comma separated columns from children.csv to include in the outputted metrics (optional), None by default
     :type child_cols: str, optional
-    :param by: units to sample from, defaults to 'recording_filename', use 'segments' to use the segments argument
+    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', 'segments' is mandatory if passing the segments argument
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
-    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the option must be set to 'segments'. Also, this option cannot be combined with options [recordings,period,from_time,to_time].
     :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
@@ -545,11 +545,11 @@ class AclewMetrics(Metrics):
     :type rec_cols: str, optional
     :param child_cols: comma separated columns from children.csv to include in the outputted metrics (optional), None by default
     :type child_cols: str, optional
-    :param by: units to sample from, defaults to 'recording_filename'
+    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', 'segments' is mandatory if passing the segments argument
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
-    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the option must be set to 'segments'. Also, this option cannot be combined with options [recordings,period,from_time,to_time].
     :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional

--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -13,7 +13,8 @@ from git.exc import InvalidGitRepositoryError
 import ChildProject
 from ChildProject.pipelines.pipeline import Pipeline
 
-import ChildProject.pipelines.metricsFunctions as metfunc #used by eval
+from ChildProject.tables import assert_dataframe, assert_columns_presence
+import ChildProject.pipelines.metricsFunctions as metfunc
 from ..utils import TimeInterval, time_intervals_intersect
 
 pipelines = {}
@@ -26,7 +27,7 @@ class Metrics(ABC):
     :type project: ChildProject.projects.ChildProject
     :param metrics_list: pandas DataFrame containing the desired metrics (metrics functions are in metricsFunctions.py)
     :type metrics_list: pd.DataFrame
-    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id), defaults to 'recording_filename'
+    :param by: unit to extract metric from (recording_filename, experiment, child_id, session_id, segments), defaults to 'recording_filename', use 'segments' to use the segments argument
     :type by: str, optional
     :param recordings: recordings to sample from; if None, all recordings will be sampled, defaults to None
     :type recordings: Union[str, List[str], pd.DataFrame], optional
@@ -40,6 +41,8 @@ class Metrics(ABC):
     :type child_cols: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
     """
@@ -54,6 +57,7 @@ class Metrics(ABC):
         rec_cols: str = None,
         child_cols: str = None,
         period: str = None,
+        segments: Union[str, pd.DataFrame] = None,
         threads: int = 1,
     ):
 
@@ -101,7 +105,7 @@ class Metrics(ABC):
         }
         #get existing columns of the dataset for recordings
         correct_cols = set(self.project.recordings.columns)
-        if by not in correct_cols: exit("<{}> is not specified in this dataset, cannot extract by it, change your --by option".format(by))
+        if by != 'segments' and by not in correct_cols: exit("<{}> is not specified in this dataset, cannot extract by it, change your --by option".format(by))
         if rec_cols:
             #when user requests recording columns, build the list and verify they exist (warn otherwise)
             rec_cols=set(rec_cols.split(","))
@@ -145,36 +149,47 @@ class Metrics(ABC):
         
         self.by = by
         self.period = period
-        
-        #build a dataframe with all the periods we will want for each unit
-        if self.period: 
-            self.periods = pd.interval_range(
-                start=datetime.datetime(1900, 1, 1, 0, 0, 0, 0),
-                end=datetime.datetime(1900, 1, 2, 0, 0, 0, 0),
-                freq=self.period,
-                closed="both",
-            )
-            self.periods= pd.DataFrame(self.periods.to_tuples().to_list(),columns=['period_start','period_end'])
-        
-        self.segments = pd.DataFrame()
-
+        self.segments = segments   
         self.recordings = Pipeline.recordings_from_list(recordings)
         
-        if from_time:
-            try:
-                self.from_time = datetime.datetime.strptime(from_time, "%H:%M:%S")
-            except:
-                raise ValueError(f"invalid value for from_time ('{from_time}'); should have HH:MM:SS format instead")
+        if segments is not None:
+            assert by == 'segments' and period is None and recordings is None and from_time is None and to_time is None, "the <segments> option can not be used with options [period,recordings,from_time,to_time], and <by> should be set to 'segments'"
+            self.segments = pd.read_csv(segments)
+
+            assert_dataframe("segments", self.segments, not_empty=True)
+            assert_columns_presence(
+                "segments",
+                self.segments,
+                {"recording_filename", "segment_onset", "segment_offset"},
+            )
         else:
-            self.from_time = None
+            
+            #build a dataframe with all the periods we will want for each unit
+            if self.period: 
+                self.periods = pd.interval_range(
+                    start=datetime.datetime(1900, 1, 1, 0, 0, 0, 0),
+                    end=datetime.datetime(1900, 1, 2, 0, 0, 0, 0),
+                    freq=self.period,
+                    closed="both",
+                )
+                self.periods= pd.DataFrame(self.periods.to_tuples().to_list(),columns=['period_start','period_end'])
+    
         
-        if to_time:
-            try:
-                self.to_time = datetime.datetime.strptime(to_time, "%H:%M:%S")
-            except:
-                raise ValueError(f"invalid value for to_time ('{to_time}'); should have HH:MM:SS format instead")
-        else:
-            self.to_time = None
+            if from_time:
+                try:
+                    self.from_time = datetime.datetime.strptime(from_time, "%H:%M:%S")
+                except:
+                    raise ValueError(f"invalid value for from_time ('{from_time}'); should have HH:MM:SS format instead")
+            else:
+                self.from_time = None
+            
+            if to_time:
+                try:
+                    self.to_time = datetime.datetime.strptime(to_time, "%H:%M:%S")
+                except:
+                    raise ValueError(f"invalid value for to_time ('{to_time}'); should have HH:MM:SS format instead")
+            else:
+                self.to_time = None
         
         self._initiate_metrics_df()
 
@@ -248,25 +263,31 @@ class Metrics(ABC):
         :return: relevant annotation DataFrame and index DataFrame
         :rtype: (pandas.DataFrame , pandas.DataFrame)
         """
-        annotations = self.am.annotations[self.am.annotations[self.by] == row[self.by]]
-        annotations = annotations[annotations["set"].isin(sets)]
-        
-        if self.from_time and self.to_time:
-            if self.period:
+        if self.segments is not None:
+            matches = self.am.get_within_ranges(ranges= pd.DataFrame(
+                    [[row['recording_filename'],row['segment_onset'], row['segment_offset']]],
+                    columns=['recording_filename','range_onset', 'range_offset']),
+                    sets= sets,
+                    missing_data = 'warn')
+        else:
+            annotations = self.am.annotations[self.am.annotations[self.by] == row[self.by]]
+            annotations = annotations[annotations["set"].isin(sets)]
+            if self.from_time and self.to_time:
+                if self.period:
+                    st_hour = row["period_start"]
+                    end_hour = row["period_end"]
+                    intervals = time_intervals_intersect(TimeInterval(self.from_time,self.to_time),TimeInterval(st_hour,end_hour))
+                    matches = pd.concat([self.am.get_within_time_range(annotations,i) for i in intervals],ignore_index =True) if intervals else pd.DataFrame()
+                else:
+                    matches = self.am.get_within_time_range(
+                    annotations, TimeInterval(self.from_time,self.to_time))
+            elif self.period:
                 st_hour = row["period_start"]
                 end_hour = row["period_end"]
-                intervals = time_intervals_intersect(TimeInterval(self.from_time,self.to_time),TimeInterval(st_hour,end_hour))
-                matches = pd.concat([self.am.get_within_time_range(annotations,i) for i in intervals],ignore_index =True) if intervals else pd.DataFrame()
-            else:
                 matches = self.am.get_within_time_range(
-                annotations, TimeInterval(self.from_time,self.to_time))
-        elif self.period:
-            st_hour = row["period_start"]
-            end_hour = row["period_end"]
-            matches = self.am.get_within_time_range(
-                    annotations, TimeInterval(st_hour,end_hour))
-        else:
-            matches = annotations
+                        annotations, TimeInterval(st_hour,end_hour))
+            else:
+                matches = annotations
 
         if matches.shape[0]:
             segments = self.am.get_segments(matches)
@@ -289,14 +310,18 @@ class Metrics(ABC):
              - 48 rows if 2 recordings in the corpus --period 1h --by recording_filename
         Then the extract() method should populate the dataframe with actual metrics
         """
-        recordings = self.project.get_recordings_from_list(self.recordings)
-        self.metrics = pd.DataFrame(recordings[self.by].unique(), columns=[self.by])
-        
-        if self.period:
-            #if period, use the self.periods dataframe to build all the list of segments per unit
-            self.metrics["key"]=0 #with old versions of pandas, we are forced to have a common column to do a cross join, we drop the column after
-            self.periods["key"]=0
-            self.metrics = pd.merge(self.metrics,self.periods,on='key',how='outer').drop('key',axis=1)
+        if self.segments is not None:
+            recordings = self.project.get_recordings_from_list(self.segments['recording_filename'].unique())
+            self.by = 'recording_filename'
+            self.metrics = self.segments.copy()
+        else:
+            recordings = self.project.get_recordings_from_list(self.recordings)
+            self.metrics = pd.DataFrame(recordings[self.by].unique(), columns=[self.by])
+            if self.period:
+                #if period, use the self.periods dataframe to build all the list of segments per unit
+                self.metrics["key"]=0 #with old versions of pandas, we are forced to have a common column to do a cross join, we drop the column after
+                self.periods["key"]=0
+                self.metrics = pd.merge(self.metrics,self.periods,on='key',how='outer').drop('key',axis=1)
         
         #add info for child_id
         self.metrics["child_id"] = self.metrics.apply(
@@ -368,10 +393,12 @@ class CustomMetrics(Metrics):
     :type rec_cols: str, optional
     :param child_cols: comma separated columns from children.csv to include in the outputted metrics (optional), None by default
     :type child_cols: str, optional
-    :param by: units to sample from, defaults to 'recording_filename'
+    :param by: units to sample from, defaults to 'recording_filename', use 'segments' to use the segments argument
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
     """
@@ -389,6 +416,7 @@ class CustomMetrics(Metrics):
         child_cols: str = None,
         by: str = "recording_filename",
         period: str = None,
+        segments: Union[str, pd.DataFrame] = None,
         threads: int = 1,
     ):
         
@@ -396,7 +424,7 @@ class CustomMetrics(Metrics):
         
         super().__init__(project, metrics_df, by=by, recordings=recordings,
              from_time=from_time, to_time=to_time, rec_cols=rec_cols,
-             child_cols=child_cols, period=period, threads=threads)
+             child_cols=child_cols, period=period, segments=segments, threads=threads)
     
     @staticmethod
     def add_parser(subparsers, subcommand):
@@ -423,10 +451,12 @@ class LenaMetrics(Metrics):
     :type rec_cols: str, optional
     :param child_cols: comma separated columns from children.csv to include in the outputted metrics (optional), None by default
     :type child_cols: str, optional
-    :param by: units to sample from, defaults to 'recording_filename'
+    :param by: units to sample from, defaults to 'recording_filename', use 'segments' to use the segments argument
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
     """
@@ -444,6 +474,7 @@ class LenaMetrics(Metrics):
         child_cols: str = None,
         by: str = "recording_filename",
         period: str = None,
+        segments: Union[str, pd.DataFrame] = None,
         threads: int = 1,
     ):
         self.set = set
@@ -470,7 +501,7 @@ class LenaMetrics(Metrics):
 
         super().__init__(project, METRICS, by=by, recordings=recordings,
              period=period, from_time=from_time, to_time=to_time, rec_cols=rec_cols,
-             child_cols=child_cols, threads=threads)
+             child_cols=child_cols, segments=segments, threads=threads)
 
         
 
@@ -515,6 +546,8 @@ class AclewMetrics(Metrics):
     :type by: str, optional
     :param period: time units to aggregate (optional); equivalent to ``pandas.Grouper`` freq argument.
     :type period: str, optional
+    :param segments: DataFrame or path to csv file of the segments to extract from, containing 'recording_filename', 'segment_onset' and 'segment_offset' columns. To use this option, the <by> option must be set to 'segments', can not be used along with options [recordings,period,from_time,to_time].
+    :type segments: Union[str, pd.DataFrame], optional
     :param threads: amount of threads to run on, defaults to 1
     :type threads: int, optional
     """
@@ -533,6 +566,7 @@ class AclewMetrics(Metrics):
         rec_cols: str = None,
         child_cols: str = None,
         period: str = None,
+        segments: Union[str, pd.DataFrame] = None,
         by: str = "recording_filename",
         threads: int = 1,
     ):
@@ -596,7 +630,8 @@ class AclewMetrics(Metrics):
 
         super().__init__(project, METRICS,by=by, recordings=recordings,
              period=period, from_time=from_time, to_time=to_time,
-             rec_cols=rec_cols, child_cols=child_cols, threads=threads)
+             rec_cols=rec_cols, child_cols=child_cols, segments=segments,
+             threads=threads)
 
     @staticmethod
     def add_parser(subparsers, subcommand):
@@ -679,8 +714,14 @@ class MetricsPipeline(Pipeline):
         parser.add_argument(
             "--by",
             help="units to sample from (default behavior is to sample by recording)",
-            choices=["recording_filename", "session_id", "child_id","experiment"],
+            choices=["recording_filename", "session_id", "child_id","experiment","segments"],
             default="recording_filename",
+        )
+        
+        parser.add_argument(
+            "--segments",
+            help="path to a CSV dataframe containing the list of segments to sample from. The CSV should have 3 columns named recording_filename, segment_onset, segment_offset. --by must be set to 'segments', Can not be used along with options [--period,--recordings,--from-tim,--to-time]",
+            default=None,
         )
         
         parser.add_argument(

--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -13,7 +13,7 @@ from git.exc import InvalidGitRepositoryError
 import ChildProject
 from ChildProject.pipelines.pipeline import Pipeline
 
-from ChildProject.tables import assert_dataframe, assert_columns_presence
+from ChildProject.tables import assert_dataframe, assert_columns_presence, read_csv_with_dtype
 import ChildProject.pipelines.metricsFunctions as metfunc
 from ..utils import TimeInterval, time_intervals_intersect
 
@@ -154,10 +154,12 @@ class Metrics(ABC):
         
         if segments is not None:
             assert by == 'segments' and period is None and recordings is None and from_time is None and to_time is None, "the <segments> option can not be combined with options [period,recordings,from_time,to_time], and <by> should be set to 'segments'"
+            
+            dtypes = {'recording_filename':'string','segment_onset':'Int64', 'segment_offset':'Int64'}
             if isinstance(segments, pd.DataFrame):
-                self.segments = segments
+                self.segments = segments.astype(dtypes)
             else:
-                self.segments = pd.read_csv(segments)
+                self.segments = read_csv_with_dtype(segments,dtypes)
 
             assert_dataframe("segments", self.segments, not_empty=True)
             assert_columns_presence(

--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -154,7 +154,10 @@ class Metrics(ABC):
         
         if segments is not None:
             assert by == 'segments' and period is None and recordings is None and from_time is None and to_time is None, "the <segments> option can not be used with options [period,recordings,from_time,to_time], and <by> should be set to 'segments'"
-            self.segments = pd.read_csv(segments)
+            if isinstance(segments, pd.DataFrame):
+                self.segments = segments
+            else:
+                self.segments = pd.read_csv(segments)
 
             assert_dataframe("segments", self.segments, not_empty=True)
             assert_columns_presence(

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -306,3 +306,12 @@ def cp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
     else:
         value = np.nan
     return value
+
+@metricFunction({},{"lena_conv_turn_type"}) 
+def lena_CVC(annotations: pd.DataFrame, duration: int, **kwargs):
+    """number of child vocalizations according to LENA's extraction
+    
+    Required keyword arguments:
+    """
+    conv_types = {'TIMR', 'TIFR'}
+    return annotations[annotations["lena_conv_turn_type"].isin(conv_types)].shape[0]

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -318,3 +318,12 @@ def lena_CVC(annotations: pd.DataFrame, duration: int, **kwargs):
     """
     conv_types = {'TIMR', 'TIFR'}
     return annotations[annotations["lena_conv_turn_type"].isin(conv_types)].shape[0]
+    
+@metricFunction(set(),{"lena_block_type"}) 
+def lena_CTC(annotations: pd.DataFrame, duration: int, **kwargs):
+    """number of conversational turn counts according to LENA's extraction
+    
+    Required keyword arguments:
+    """
+    block_types = {'AICF', 'AICM', 'CIC', 'XIC'}
+    return annotations[annotations["lena_block_type"].isin(block_types)].shape[0]

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -35,18 +35,21 @@ def metricFunction(args: set, columns: set, emptyValue = 0, name : str = None):
         def new_func(annotations: pd.DataFrame, duration: int, **kwargs):
             for arg in args:
                 if arg not in kwargs : raise ValueError('{} metric needs an argument <{}>'.format(function.__name__,arg))
-            metname = name
-            if not name : metname = function.__name__
-            metname_replaced = metname
+            metric_name = name
+            if not name : metric_name = function.__name__
+            metric_name_replaced = metric_name
+            #metric_name is the basename used to designate this metric (voc_speaker_ph), metric_name_replaced replaces the values of kwargs
+            #found in the name by their values, giving the metric name for that instance only (voc_chi_ph)
             for arg in kwargs:
-                metname_replaced = re.sub(arg , str(kwargs[arg]).lower(),metname_replaced)
+                metric_name_replaced = re.sub(arg , str(kwargs[arg]).lower(),metric_name_replaced)
             if annotations.shape[0]:
-                for column in columns:
-                    if column not in annotations.columns : raise ValueError(MISSING_COLUMNS.format(annotations['set'].iloc[0],column,metname))
+                missing_columns = columns - set(annotations.columns)
+                if missing_columns:
+                    raise ValueError(MISSING_COLUMNS.format(annotations['set'].iloc[0],missing_columns,metric_name))
                 res = function(annotations, duration, **kwargs)
             else: #no annotation for that unit
                 res = emptyValue if duration else None #duration != 0 => was annotated but not segments there
-            return metname_replaced, res
+            return metric_name_replaced, res
         return new_func
     return decorator
             
@@ -225,7 +228,7 @@ def avg_non_can_voc_dur_speaker(annotations: pd.DataFrame, duration: int, **kwar
     if pd.isnull(value) : value = 0
     return value
 
-@metricFunction({},{},np.nan)
+@metricFunction(set(),set(),np.nan)
 def lp_n(annotations: pd.DataFrame, duration: int, **kwargs):
     """linguistic proportion on the number of vocalizations for CHI (based on vcm_type or [cries,vfxs,utterances_count] if vcm_type does not exist)
     
@@ -253,7 +256,7 @@ def lp_n(annotations: pd.DataFrame, duration: int, **kwargs):
         raise ValueError("the given set does not have the neccessary columns for this metric, choose a set that contains either [vcm_type] or [cries,vfxs,utterances_count]")
     return value
 
-@metricFunction({},{"speaker_type","vcm_type"},np.nan)
+@metricFunction(set(),{"speaker_type","vcm_type"},np.nan)
 def cp_n(annotations: pd.DataFrame, duration: int, **kwargs):
     """canonical proportion on the number of vocalizations for CHI (based on vcm_type)
     
@@ -267,7 +270,7 @@ def cp_n(annotations: pd.DataFrame, duration: int, **kwargs):
         value = np.nan
     return value
     
-@metricFunction({},{},np.nan)
+@metricFunction(set(),set(),np.nan)
 def lp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
     """linguistic proportion on the duration of vocalizations for CHI (based on vcm_type or [child_cry_vfxs_len,utterances_length] if vcm_type does not exist)
     
@@ -293,7 +296,7 @@ def lp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
         raise ValueError("the {} set does not have the neccessary columns for this metric, choose a set that contains either [vcm_type] or [child_cry_vfx_len,utterances_length]")
     return value
 
-@metricFunction({},{"speaker_type","vcm_type","duration"},np.nan)
+@metricFunction(set(),{"speaker_type","vcm_type","duration"},np.nan)
 def cp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
     """canonical proportion on the number of vocalizations for CHI (based on vcm_type)
     
@@ -307,7 +310,7 @@ def cp_dur(annotations: pd.DataFrame, duration: int, **kwargs):
         value = np.nan
     return value
 
-@metricFunction({},{"lena_conv_turn_type"}) 
+@metricFunction(set(),{"lena_conv_turn_type"}) 
 def lena_CVC(annotations: pd.DataFrame, duration: int, **kwargs):
     """number of child vocalizations according to LENA's extraction
     

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -51,6 +51,14 @@ def metricFunction(args: set, columns: set, emptyValue = 0, name : str = None):
     return decorator
             
 
+@metricFunction({"speaker"},{"speaker_type"}) 
+def voc_speaker(annotations: pd.DataFrame, duration: int, **kwargs):
+    """number of vocalizations for a given speaker type
+    
+    Required keyword arguments:
+        - speaker : speaker_type to use
+    """
+    return annotations[annotations["speaker_type"]== kwargs["speaker"]].shape[0]
 
 @metricFunction({"speaker"},{"speaker_type"}) 
 def voc_speaker_ph(annotations: pd.DataFrame, duration: int, **kwargs):

--- a/ChildProject/tables.py
+++ b/ChildProject/tables.py
@@ -15,7 +15,8 @@ class MissingColumnsException(Exception):
         )
         
 class IncorrectDtypeException(Exception):
-    #Exception when an Unexpected DType is found in a pandas DataFrame 
+    """Exception when an Unexpected DType is found in a pandas DataFrame
+    """
 
 def assert_dataframe(name: str, df: pd.DataFrame, not_empty: bool = False):
     assert isinstance(

--- a/ChildProject/tables.py
+++ b/ChildProject/tables.py
@@ -15,11 +15,7 @@ class MissingColumnsException(Exception):
         )
         
 class IncorrectDtypeException(Exception):
-    def __init__(self, error: str):
-
-        super().__init__(
-            error
-        )
+    #Exception when an Unexpected DType is found in a pandas DataFrame 
 
 def assert_dataframe(name: str, df: pd.DataFrame, not_empty: bool = False):
     assert isinstance(

--- a/ChildProject/tables.py
+++ b/ChildProject/tables.py
@@ -13,7 +13,13 @@ class MissingColumnsException(Exception):
         super().__init__(
             f"dataframe {name} misses the following required columns: {missing}"
         )
+        
+class IncorrectDtypeException(Exception):
+    def __init__(self, error: str):
 
+        super().__init__(
+            error
+        )
 
 def assert_dataframe(name: str, df: pd.DataFrame, not_empty: bool = False):
     assert isinstance(
@@ -29,6 +35,13 @@ def assert_columns_presence(name: str, df: pd.DataFrame, columns: Union[Set, Lis
 
     if len(missing):
         raise MissingColumnsException(name, missing)
+        
+def read_csv_with_dtype(file: str, dtypes: dict):
+    try:
+        df = pd.read_csv(file,dtype=dtypes)
+    except ValueError:
+        raise IncorrectDtypeException('Incorrect type found in {}, expected column types are:\n{}'.format(file,dtypes))
+    return df
 
 
 def is_boolean(x):

--- a/tests/data/segments.csv
+++ b/tests/data/segments.csv
@@ -1,0 +1,3 @@
+recording_filename,segment_onset,segment_offset
+sound.wav,0,1000
+sound.wav,1500,4000

--- a/tests/truth/segments_metrics.csv
+++ b/tests/truth/segments_metrics.csv
@@ -1,0 +1,3 @@
+recording_filename,segment_onset,segment_offset,child_id,experiment,child_dob,date_iso,duration_segments_alice,wc_fem_ph,duration_segments_vcm,lp_n,lp_dur,duration_segments_vtc,voc_fem,voc_chi,voc_fem_ph,voc_chi_ph
+sound.wav,0,1000,1,test,2020-01-01,2020-04-20,1000,7200.0,1000,1.0,1.0,1000,2,5,7200.0,18000.0
+sound.wav,1500,4000,1,test,2020-01-01,2020-04-20,2500,7200.0,2500,1.0,1.0,2500,5,12,7200.0,17280.0


### PR DESCRIPTION
Add the --segments option to the metrics pipeline.
This option extracts metrics only on the required segments in a dataFrame having 'recording_filename', 'segment_onset' and 'segment_offset'.
Use this option with `--by segments`
- [X] implementation
- [X] tests
- [X] docstrings