### PR TITLE
Annotations/merge single annot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Start times can include seconds (e.g. 12:34:59) while still accepting the old format (This change will allow other columns to accept multiple formats easily).
 - `child-project --version` command
+- `merge_sets` in `AnnotationManager` method now accepts arguments [full_set_merge,skip_existing,recording_filter] to carry out partial merges
 
 ### Changed
 

--- a/docs/source/annotations.rst
+++ b/docs/source/annotations.rst
@@ -125,10 +125,10 @@ and VTC annotations altogether. This can be done with ``child-project merge-anno
 
    child-project merge-annotations /path/to/dataset \
    --left-set vtc \
-   --right-set alice \
-   --left-columns speaker_id,ling_type,speaker_type,vcm_type,lex_type,mwu_type,addresseee,transcription \
+   --right-set alice/output \
+   --left-columns speaker_type \
    --right-columns phonemes,syllables,words \
-   --output-set alice_vtc
+   --output-set alice
 
 Intersect annotations
 ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/valid_raw_data/annotations/input.csv
+++ b/examples/valid_raw_data/annotations/input.csv
@@ -7,3 +7,5 @@ alice,sound.wav,0,example_alice.txt,1980000,1990000,alice,namibie_aiku_20160714_
 metrics,sound.wav,0,example_metrics.rttm,0,100000000,vtc_rttm,tsimane2017_C01_20170706
 old_its,sound.wav,0,example_lena_old.its,0,100000000,its,
 new_its,sound.wav,0,example_lena_new.its,0,100000000,its,
+vtc_rttm,sound2.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1
+alice,sound2.wav,0,example_alice.txt,1980000,1990000,alice,namibie_aiku_20160714_1

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -192,6 +192,7 @@ def test_intersect(project):
     columns = a.columns.tolist()
     columns.remove("imported_at")
     columns.remove("package_version")
+    columns.remove("merged_from")
 
     pd.testing.assert_frame_equal(
         standardize_dataframe(a, columns),
@@ -295,6 +296,7 @@ def test_merge(project):
         adult_segments[["phonemes", "syllables", "words"]],
         alice[["phonemes", "syllables", "words"]],
     )
+    #assert False
 
 
 def test_clipping(project):


### PR DESCRIPTION
Allow merging to be done with increments by having:
- `skip_existing` option skipping all the existing converted files
- `recording_filter` merging only the lines belonging to the recording_filename values  in this set
- `full_merge_set` Allowing to merge even if the set already exists