### PR TITLE
Annotations/enforce unicity

### DIFF
--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -463,7 +463,8 @@ class AnnotationManager:
             if overwrite_existing:
                 print(f"Warning: annotation file {output_filename} will be overwritten")
             else:
-                annotation["error"] = f"annotation file {output_filename} already exists, to reimport it, use the overwrite_existing flag"
+                error_filename = output_filename.replace('\\','/')
+                annotation["error"] = f"annotation file {error_filename} already exists, to reimport it, use the overwrite_existing flag"
                 print(f"Error: {annotation['error']}")
                 annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 return annotation

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -411,6 +411,7 @@ class AnnotationManager:
         self.annotations[
             ["time_seek", "range_onset", "range_offset"]
         ] = self.annotations[["time_seek", "range_onset", "range_offset"]].astype(np.int64)
+        self.annotations = self.annotations.sort_values(['imported_at','set', 'annotation_filename'])
         self.annotations.to_csv(
             os.path.join(self.project.path, "metadata/annotations.csv"), index=False
         )

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -13,7 +13,7 @@ from . import __version__
 from .projects import ChildProject
 from .converters import *
 from .tables import IndexTable, IndexColumn, assert_dataframe, assert_columns_presence
-from .utils import Segment, intersect_ranges, path_is_parent, TimeInterval, series_to_datetime
+from .utils import Segment, intersect_ranges, path_is_parent, TimeInterval, series_to_datetime, find_lines_involved_in_overlap
 
 
 class AnnotationManager:
@@ -428,9 +428,12 @@ class AnnotationManager:
                             warnings.append("set {} is outdated because the {} set it is merged from was modified. Consider updating or rerunning the creation of the {} set.".format(i,j,i))
                         
         return warnings
-
+        
     def _import_annotation(
-        self, import_function: Callable[[str], pd.DataFrame], params: dict, annotation: dict
+        self, import_function: Callable[[str], pd.DataFrame],
+        params: dict,
+        annotation: dict,
+        overwrite_existing: bool = False,
     ):
         """import and convert ``annotation``. This function should not be called outside of this class.
 
@@ -440,6 +443,8 @@ class AnnotationManager:
         :type params: dict
         :param annotation: input annotation dictionary (attributes defined according to :ref:`ChildProject.annotations.AnnotationManager.SEGMENTS_COLUMNS`)
         :type annotation: dict
+        :param overwrite_existing: choose if lines with the same set and annotation_filename should be overwritten
+        :type overwrite_existing: bool
         :return: output annotation dictionary (attributes defined according to :ref:`ChildProject.annotations.AnnotationManager.SEGMENTS_COLUMNS`)
         :rtype: dict
         """
@@ -451,7 +456,32 @@ class AnnotationManager:
         output_filename = os.path.join(
             "annotations", annotation["set"], "converted", annotation_filename
         )
-
+        
+        #check if the annotation file already exists in dataset (same filename and same set)
+        if self.annotations[(self.annotations['set'] == annotation['set']) &
+                            (self.annotations['annotation_filename'] == annotation_filename)].shape[0] > 0:
+            if overwrite_existing:
+                print(f"Warning: annotation file {output_filename} will be overwritten")
+            else:
+                annotation["error"] = f"annotation file {output_filename} already exists, to reimport and\
+                reimport it, use the overwrite_existing flag"
+                print(f"Error: {annotation['error']}")
+                annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                return annotation
+        
+        #find if there are annotation indexes in the same set that overlap the new annotation
+        #as it is not possible to annotate multiple times the same audio stretch in the same set
+        ovl_annots = self.annotations[(self.annotations['set'] == annotation['set']) &
+                            (self.annotations['recording_filename'] == annotation['recording_filename']) &
+                            (self.annotations['range_onset'] < annotation['range_offset']) &
+                            (self.annotations['range_offset'] > annotation['range_onset']) 
+                            ]
+        if ovl_annots.shape[0] > 0:
+            annotation["error"] = f"importation for set <{annotation['set']}> recording <{annotation['recording_filename']}> from {annotation['range_onset']} to {annotation['range_offset']} cannot continue because it overlaps with these existing annotation indexes: \n{ovl_annots}"
+            print(f"Error: {annotation['error']}")
+            annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            return annotation
+            
         path = os.path.join(
             self.project.path,
             "annotations",
@@ -486,6 +516,7 @@ class AnnotationManager:
             print(traceback.format_exc(), file=sys.stderr)
 
         if df is None or not isinstance(df, pd.DataFrame):
+            annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return annotation
 
         if not df.shape[1]:
@@ -535,6 +566,7 @@ class AnnotationManager:
         threads: int = -1,
         import_function: Callable[[str], pd.DataFrame] = None,
         new_tiers: list = None,
+        overwrite_existing: bool = False,
     ) -> pd.DataFrame:
         """Import and convert annotations.
 
@@ -546,6 +578,8 @@ class AnnotationManager:
         :type import_function: Callable[[str], pd.DataFrame], optional
         :param new_tiers: List of EAF tiers names. If specified, the corresponding EAF tiers will be imported.
         :type new_tiers: list[str], optional
+        :param overwrite_existing: choose if lines with the same set and annotation_filename should be overwritten
+        :type overwrite_existing: bool, optional
         :return: dataframe of imported annotations, as in :ref:`format-annotations`.
         :rtype: pd.DataFrame
         """
@@ -583,15 +617,21 @@ class AnnotationManager:
                 "warning: some of the converters do not support multithread importation; running on 1 thread"
             )
             threads = 1
+            
+        #if the input to import has overlaps in it, raise an error immediately, nothing will be imported
+        ovl_ranges = find_lines_involved_in_overlap(input_processed, recording_label='recording_filename', set_label='set')
+        if ovl_ranges[ovl_ranges == True].shape[0] > 0:
+            ovl_ranges = ovl_ranges[ovl_ranges].index.values.tolist()
+            raise ValueError(f"the ranges given to import have overlaps on indexes : {ovl_ranges}")
 
         if threads == 1:
             imported = input_processed.apply(
-                partial(self._import_annotation, import_function, {"new_tiers": new_tiers}), axis=1
+                partial(self._import_annotation, import_function, {"new_tiers": new_tiers}, overwrite_existing), axis=1
             ).to_dict(orient="records")
         else:
             with mp.Pool(processes=threads if threads > 0 else mp.cpu_count()) as pool:
                 imported = pool.map(
-                    partial(self._import_annotation, import_function, {"new_tiers": new_tiers}),
+                    partial(self._import_annotation, import_function, {"new_tiers": new_tiers}, overwrite_existing),
                     input_processed.to_dict(orient="records"),
                 )
 
@@ -601,9 +641,20 @@ class AnnotationManager:
             axis=1,
             inplace=True,
         )
+        errors = imported[imported["error"].isnull()]
+        imported = imported[~imported["error"].isnull()]
+        
+        #when errors occur, separate them in a different csv in extra
+        if errors.shape[0] > 0:
+            output = os.path.join(self.project.path, "extra","errors_import_{}.csv".format(datetime.datetime.now().strftime("%Y%m%d-%H%M%S")))
+            errors.to_csv(output, index=False)
+            print(f"Errors summary exported to {output}")
 
         self.read()
         self.annotations = pd.concat([self.annotations, imported], sort=False)
+        #at this point, 2 lines with same set and annotation_filename can happen if specified overwrite,
+        # dropping duplicates remove the first importation and keeps the more recent one
+        self.annotations = self.annotations.sort_values('imported_at').drop_duplicates(subset=["set","annotation_filename"], keep='last')
         self.write()
         
         sets = set(input_processed['set'].unique())

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -589,6 +589,9 @@ class AnnotationManager:
         
         input_processed["range_onset"] = input_processed["range_onset"].astype(np.int64)
         input_processed["range_offset"] = input_processed["range_offset"].astype(np.int64)
+        
+        assert (input_processed["range_offset"] > input_processed["range_onset"]).all(), "range_offset must be greater than range_onset"
+        assert (input_processed["range_onset"] >= 0).all(), "range_onset must be greater or equal to 0"
 
         required_columns = {
             c.name

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -479,7 +479,7 @@ class AnnotationManager:
                             ]
         if ovl_annots.shape[0] > 0:
             array_tup = list(ovl_annots[['set','recording_filename','range_onset', 'range_offset']].itertuples(index=False, name=None))
-            annotation["error"] = f"importation for set <{annotation['set']}> recording <{annotation['recording_filename']}> from {annotation['range_onset']} to {annotation['range_offset']} cannot continue because it overlaps with these existing annotation lines: \n{array_tup}"
+            annotation["error"] = f"importation for set <{annotation['set']}> recording <{annotation['recording_filename']}> from {annotation['range_onset']} to {annotation['range_offset']} cannot continue because it overlaps with these existing annotation lines: {array_tup}"
             print(f"Error: {annotation['error']}")
             annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return annotation

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -321,7 +321,7 @@ class AnnotationManager:
             )
                 
         #check the index for overlaps, produces errors as the same set should not have overlaps in annotations
-        ovl_ranges = find_lines_involved_in_overlap(self.annotations, recording_label='recording_filename', set_label='set')
+        ovl_ranges = find_lines_involved_in_overlap(self.annotations, labels=['recording_filename', 'set'])
         if ovl_ranges[ovl_ranges == True].shape[0] > 0:
             ovl_ranges = self.annotations[ovl_ranges][['set','annotation_filename']].values.tolist()
             errors.extend(
@@ -642,7 +642,7 @@ class AnnotationManager:
             threads = 1
             
         #if the input to import has overlaps in it, raise an error immediately, nothing will be imported
-        ovl_ranges = find_lines_involved_in_overlap(input_processed, recording_label='recording_filename', set_label='set')
+        ovl_ranges = find_lines_involved_in_overlap(input_processed, labels=['recording_filename','set'])
         if ovl_ranges[ovl_ranges == True].shape[0] > 0:
             ovl_ranges = ovl_ranges[ovl_ranges].index.values.tolist()
             raise ValueError(f"the ranges given to import have overlaps on indexes : {ovl_ranges}")

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -478,7 +478,8 @@ class AnnotationManager:
                             (self.annotations['range_offset'] > annotation['range_onset']) 
                             ]
         if ovl_annots.shape[0] > 0:
-            annotation["error"] = f"importation for set <{annotation['set']}> recording <{annotation['recording_filename']}> from {annotation['range_onset']} to {annotation['range_offset']} cannot continue because it overlaps with these existing annotation lines: \n{ovl_annots}"
+            array_tup = list(ovl_annots[['set','recording_filename','range_onset', 'range_offset']].itertuples(index=False, name=None))
+            annotation["error"] = f"importation for set <{annotation['set']}> recording <{annotation['recording_filename']}> from {annotation['range_onset']} to {annotation['range_offset']} cannot continue because it overlaps with these existing annotation lines: \n{array_tup}"
             print(f"Error: {annotation['error']}")
             annotation["imported_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return annotation

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -319,6 +319,23 @@ class AnnotationManager:
                     for dup in duplicates.to_dict(orient="records")
                 ]
             )
+                
+        #check the index for overlaps, produces errors as the same set should not have overlaps in annotations
+        ovl_ranges = find_lines_involved_in_overlap(self.annotations, recording_label='recording_filename', set_label='set')
+        if ovl_ranges[ovl_ranges == True].shape[0] > 0:
+            ovl_ranges = self.annotations[ovl_ranges][['set','annotation_filename']].values.tolist()
+            errors.extend(
+                [
+                    f"overlaps in the annotation index for the following [set, annotation_filename] list: {ovl_ranges}"
+                ]
+            )
+            
+        ranges_invalid = self.annotations[(self.annotations['range_offset'] <= self.annotations['range_onset']) | (self.annotations['range_onset'] < 0)]
+        if ranges_invalid.shape[0] > 0:
+            errors.extend(
+                [f"annotation index does not verify range_offset > range_onset >= 0 for set <{line['set']}>, annotation filename <{line['annotation_filename']}>"
+                  for line in ranges_invalid.to_dict(orient="records")]        
+            )
         
         warnings += self._check_for_outdated_merged_sets()
 

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -159,8 +159,7 @@ def validate(args):
             "--annotations",
             help="path to input annotations dataframe (csv) [only for bulk importation]",
             default="",
-        ),
-        arg("--threads", help="amount of threads to run on", type=int, default=0),
+        ),       
     ]
     + [
         arg(
@@ -172,7 +171,11 @@ def validate(args):
         )
         for col in AnnotationManager.INDEX_COLUMNS
         if not col.generated
-    ]
+    ] +
+    [
+     arg("--threads", help="amount of threads to run on", type=int, default=0),
+     arg("--overwrite-existing","--ov", help="overwrites existing annotation file if should generate the same output file (useful when reimporting", action='store_true'),
+     ]
 )
 def import_annotations(args):
     """convert and import a set of annotations"""

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -174,7 +174,7 @@ def validate(args):
     ] +
     [
      arg("--threads", help="amount of threads to run on", type=int, default=0),
-     arg("--overwrite-existing","--ov", help="overwrites existing annotation file if should generate the same output file (useful when reimporting", action='store_true'),
+     arg("--overwrite-existing","--ow", help="overwrites existing annotation file if should generate the same output file (useful when reimporting", action='store_true'),
      ]
 )
 def import_annotations(args):

--- a/ChildProject/cmdline.py
+++ b/ChildProject/cmdline.py
@@ -198,20 +198,25 @@ def import_annotations(args):
         )
 
     am = AnnotationManager(project)
-    imported = am.import_annotations(annotations, args.threads)
-
-    errors, warnings = am.validate(annotations=imported, threads=args.threads)
-
-    if len(am.errors) > 0:
-        print(
-            "importation completed with {} errors and {} warnings".format(
-                len(am.errors) + len(errors), len(warnings)
-            ),
-            file=sys.stderr,
-        )
-        print("\n".join(am.errors), file=sys.stderr)
-        print("\n".join(errors), file=sys.stderr)
-        print("\n".join(warnings))
+    imported, errors_imp = am.import_annotations(annotations, args.threads, overwrite_existing=args.overwrite_existing)
+    
+    if errors_imp is not None and errors_imp.shape[0] > 0:
+        print("the importation failed for {} entry/ies".format(errors_imp.shape[0]))
+        print(errors_imp)
+    
+    if imported is not None and imported.shape[0] > 0:
+        errors, warnings = am.validate(imported, threads=args.threads)
+    
+        if len(am.errors) > 0:
+            print(
+                "in the resulting annotations {} errors and {} warnings were found".format(
+                    len(am.errors) + len(errors), len(warnings)
+                ),
+                file=sys.stderr,
+            )
+            print("\n".join(am.errors), file=sys.stderr)
+            print("\n".join(errors), file=sys.stderr)
+            print("\n".join(warnings))
 
 
 @subcommand(

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -177,7 +177,7 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
 
     return res,len(ref)
 
-def find_lines_involved_in_overlap(df: pd.DataFrame, onset_label: str = 'range_onset', offset_label:str = 'range_offset', labels: list[str] = []):
+def find_lines_involved_in_overlap(df: pd.DataFrame, onset_label: str = 'range_onset', offset_label:str = 'range_offset', labels = []):
     """
     takes a dataframe as input. The dataframe is supposed to have a column for the onset
     og a timeline and one for the offset. The function returns a boolean series where

--- a/ChildProject/utils.py
+++ b/ChildProject/utils.py
@@ -177,7 +177,7 @@ def calculate_shift(file1, file2, start1, start2, interval, correlation_output =
 
     return res,len(ref)
 
-def find_lines_involved_in_overlap(df: pd.DataFrame, onset_label: str = 'range_onset', offset_label:str = 'range_offset', recording_label: str= None, set_label: str = None):
+def find_lines_involved_in_overlap(df: pd.DataFrame, onset_label: str = 'range_onset', offset_label:str = 'range_offset', labels: list[str] = []):
     """
     takes a dataframe as input. The dataframe is supposed to have a column for the onset
     og a timeline and one for the offset. The function returns a boolean series where
@@ -197,22 +197,16 @@ def find_lines_involved_in_overlap(df: pd.DataFrame, onset_label: str = 'range_o
     :type onset_label: str
     :param offset_label: columns label for the offset of time segments
     :type offset_label: str
-    :param recording_label: column label for rec name, to avoid finding overlaps across different recs. When 'None', considers every line to be on the same rec.
-    :type recording_label: str
+    :param labels: list of column labels that are required to match to be involved in overlap.
+    :type labels: list[str]
     :return: pandas Series of boolean values where 'True' are indexes where overlaps exist
     :rtype: pd.Series
     """
+    conditions = f"(df['{onset_label}'] < row['{offset_label}']) & (df['{offset_label}'] > row['{onset_label}']) & (df.index != row.name)"
+    for l in labels:
+        conditions = "(df['{}'] == row['{}']) & ".format(l,l) + conditions
     #overlap is defined by having s2.offset > s1.onset and s2.onset < s1.offset and s2.index != s1.index (same seg)
-    if recording_label is None:
-        if set_label is None:
-            return df.apply(lambda row: True if df[(df[onset_label] < row[offset_label]) & (df[offset_label] > row[onset_label]) & (df.index != row.name)].shape[0] else False,axis=1)
-        else:
-            return df.apply(lambda row: True if df[(df[set_label] == row[set_label]) & (df[onset_label] < row[offset_label]) & (df[offset_label] > row[onset_label]) & (df.index != row.name)].shape[0] else False,axis=1) 
-    else:
-        if set_label is None:
-            return df.apply(lambda row: True if df[(df[recording_label] == row[recording_label]) & (df[onset_label] < row[offset_label]) & (df[offset_label] > row[onset_label]) & (df.index != row.name)].shape[0] else False,axis=1)
-        else:
-            return df.apply(lambda row: True if df[(df[set_label] == row[set_label]) & (df[recording_label] == row[recording_label]) & (df[onset_label] < row[offset_label]) & (df[offset_label] > row[onset_label]) & (df.index != row.name)].shape[0] else False,axis=1)
+    return df.apply(lambda row: True if df[eval(conditions)].shape[0] else False,axis=1) 
 
 def series_to_datetime(time_series, time_index_list, time_column_name:str, date_series = None, date_index_list = None, date_column_name = None):
     """

--- a/examples/invalid_raw_data/metadata/annotations.csv
+++ b/examples/invalid_raw_data/metadata/annotations.csv
@@ -1,0 +1,9 @@
+set,recording_filename,time_seek,range_onset,range_offset,raw_filename,format,filter,annotation_filename,imported_at,package_version,error,merged_from
+textgrid,sound.wav,0,0,300000,example.TextGrid,TextGrid,,sound_0_10000.csv,2023-02-07 12:15:18,0.0.7,,
+textgrid,sound.wav,0,200000,400000,example.eaf,eaf,,sound_0_300000.csv,2023-02-07 12:15:18,0.0.7,,
+textgrid,sound.wav,0,0,40000000,example_solis.eaf,eaf,,sound_0_40000000.csv,2023-02-07 12:15:18,0.0.7,,
+vtc_rttm,sound.wav,0,1980000,1990000,example.rttm,vtc_rttm,namibie_aiku_20160714_1,sound_1980000_1990000.csv,2023-02-07 12:15:18,0.0.7,,
+alice,sound.wav,0,1980000,1990000,example_alice.txt,alice,namibie_aiku_20160714_1,sound_1980000_1990000.csv,2023-02-07 12:15:18,0.0.7,,
+alice,sound.wav,0,0,10000,example_metrics.rttm,vtc_rttm,tsimane2017_C01_20170706,sound_0_100000000.csv,2023-02-07 12:15:18,0.0.7,,
+vtc_rttm,sound.wav,0,1980000,1990000,example.rttm,vtc_rttm,namibie_aiku_20160714_1,sound_1980000_1990000.csv,2023-02-07 12:15:18,0.0.7,,
+ranges,sound.wav,0,200000,100000,example.eaf,eaf,,sound_0_300000.csv,2023-02-07 12:15:18,0.0.7,,

--- a/examples/valid_raw_data/annotations/textgrid2/raw/example.TextGrid
+++ b/examples/valid_raw_data/annotations/textgrid2/raw/example.TextGrid
@@ -1,0 +1,158 @@
+File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0 
+xmax = 10 
+tiers? <exists> 
+size = 11 
+item []: 
+    item [1]:
+        class = "IntervalTier" 
+        name = "    CHI*" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 1.602202475775698 
+            text = "" 
+        intervals [2]:
+            xmin = 1.602202475775698 
+            xmax = 2.2149350364643396 
+            text = "1" 
+        intervals [3]:
+            xmin = 2.2149350364643396 
+            xmax = 10 
+            text = "" 
+    item [2]:
+        class = "IntervalTier" 
+        name = "    MOT*" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 5.592624999999998 
+            text = "" 
+        intervals [2]:
+            xmin = 5.592624999999998 
+            xmax = 7.520937500000002 
+            text = "1" 
+        intervals [3]:
+            xmin = 7.520937500000002 
+            xmax = 10 
+            text = "" 
+    item [3]:
+        class = "IntervalTier" 
+        name = "    C1" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 2.2149350364643396 
+            text = "" 
+        intervals [2]:
+            xmin = 2.2149350364643396 
+            xmax = 3.319749999999999 
+            text = "1" 
+        intervals [3]:
+            xmin = 3.319749999999999 
+            xmax = 10 
+            text = "" 
+    item [4]:
+        class = "IntervalTier" 
+        name = "    C2" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 4.100265992429456 
+            text = "" 
+        intervals [2]:
+            xmin = 4.100265992429456 
+            xmax = 5.209750000000014 
+            text = "1" 
+        intervals [3]:
+            xmin = 5.209750000000014 
+            xmax = 10 
+            text = "" 
+    item [5]:
+        class = "IntervalTier" 
+        name = "    FA1" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 
+    item [6]:
+        class = "IntervalTier" 
+        name = "    FA2" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 
+    item [7]:
+        class = "IntervalTier" 
+        name = "    MA1" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 
+    item [8]:
+        class = "IntervalTier" 
+        name = "    MA2" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 
+    item [9]:
+        class = "IntervalTier" 
+        name = "    2POPMT" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 
+    item [10]:
+        class = "IntervalTier" 
+        name = "    LF2P" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 3 
+        intervals [1]:
+            xmin = 0 
+            xmax = 8.100562500000024 
+            text = "" 
+        intervals [2]:
+            xmin = 8.100562500000024 
+            xmax = 9.284926121333484 
+            text = "1" 
+        intervals [3]:
+            xmin = 9.284926121333484 
+            xmax = 10 
+            text = "" 
+    item [11]:
+        class = "IntervalTier" 
+        name = "Autre" 
+        xmin = 0 
+        xmax = 10 
+        intervals: size = 1 
+        intervals [1]:
+            xmin = 0 
+            xmax = 10 
+            text = "" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ python-dateutil>=2.8.1
 PyYAML
 requests==2.25.0
 scipy
-sklearn
+scikit-learn
 sphinx
 sphinx_rtd_theme==1.1.1
 sphinx-tabs==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = open(os.path.join(DIRECTORY, "README.md")).read()
 requires = {
     "core": ["pandas>=1.1.0,<=1.5.0", "jinja2", "numpy>=1.16.5", "datalad"],
     "annotations": ["lxml", "pympi-ling", "pylangacq", "python-dateutil>=2.8.1"],
-    "metrics": ['pyannote.metrics; python_version >= "3.7.0"', "nltk", "sklearn", "GitPython"],
+    "metrics": ['pyannote.metrics; python_version >= "3.7.0"', "nltk", "scikit-learn", "GitPython"],
     "audio": ["librosa", "pydub", "pysoundfile"],
     "samplers": ["PyYAML"],
     "zooniverse": ["panoptes-client", "praat-parselmouth"],

--- a/tests/data/input_importoverlaps.csv
+++ b/tests/data/input_importoverlaps.csv
@@ -1,0 +1,6 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,note
+textgrid,sound.wav,0,example.TextGrid,0,5000,TextGrid,,overlaps
+eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,same namefile
+eaf_solis,sound.wav,0,example_solis.eaf,40000000,80000000,eaf,,shoud succeed +1 line
+textgrid,sound2.wav,0,example.TextGrid,0,10000,TextGrid,,shoud succeed +1 line bc diff rec
+textgrid2,sound.wav,0,example.TextGrid,0,10000,TextGrid,,shoud succeed +1 line bc diff set

--- a/tests/data/input_invalid.csv
+++ b/tests/data/input_invalid.csv
@@ -1,0 +1,4 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter
+textgrid,sound.wav,0,example.TextGrid,0,10000,TextGrid,
+textgrid,sound.wav,0,example.TextGrid,9900,300000,eaf,
+textgrid,sound.wav,0,example.TextGrid,300001,40000000,eaf,

--- a/tests/data/input_reimport.csv
+++ b/tests/data/input_reimport.csv
@@ -1,0 +1,11 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,note
+textgrid,sound.wav,0,example.TextGrid,0,10000,TextGrid,,should fail without ow
+eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,should fail without ow
+eaf_solis,sound.wav,0,example_solis.eaf,0,40000000,eaf,,should fail without ow
+vtc_rttm,sound.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,should fail without ow
+alice,sound.wav,0,example_alice.txt,1980000,1990000,alice,namibie_aiku_20160714_1,should fail without ow
+metrics,sound.wav,0,example_metrics.rttm,0,100000000,vtc_rttm,tsimane2017_C01_20170706,should fail without ow
+old_its,sound.wav,0,example_lena_old.its,0,100000000,its,,should fail without ow
+new_its,sound.wav,0,example_lena_new.its,0,100000000,its,,should fail without ow
+vtc_rttm,sound2.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,should fail without ow
+alice,sound2.wav,0,example_alice.txt,1990000,2000000,alice,namibie_aiku_20160714_1,should always work

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -17,18 +17,22 @@ def standardize_dataframe(df, columns):
     df = df[list(columns)]
     return df.sort_index(axis=1).sort_values(list(columns)).reset_index(drop=True)
 
+DATA = os.path.join('tests', 'data')
+TRUTH = os.path.join('tests', 'truth')
+
 
 @pytest.fixture(scope="function")
 def project(request):
     if not os.path.exists("output/annotations"):
         shutil.copytree(src="examples/valid_raw_data", dst="output/annotations")
+      
+    if os.path.isfile("output/annotations/metadata/annotations.csv"):
+        os.remove("output/annotations/metadata/annotations.csv")
+    for raw_annotation in glob.glob("output/annotations/annotations/*/converted"):
+        shutil.rmtree(raw_annotation)
 
     project = ChildProject("output/annotations")
     yield project
-
-    os.remove("output/annotations/metadata/annotations.csv")
-    for raw_annotation in glob.glob("output/annotations/annotations/*.*/converted"):
-        shutil.rmtree(raw_annotation)
 
 
 def test_csv():
@@ -178,6 +182,77 @@ def test_import(project):
             check_exact=False,
             rtol= 1e-3
         )
+ 
+# test how the importation handles already existing files and overlaps in importation
+@pytest.mark.parametrize("input_file,ow,rimported,rerrors,exception", 
+                         [("input_invalid.csv", False,None,None,ValueError),
+                         ("input_reimport.csv", False,"imp_reimport_no_ow.csv","err_reimport_no_ow.csv",None),
+                         ("input_reimport.csv", True,"imp_reimport_ow.csv",None,None),
+                         ("input_importoverlaps.csv", False,"imp_overlap.csv","err_overlap.csv",None),
+                         ])
+def test_multiple_imports(project, input_file, ow, rimported, rerrors, exception):
+    am = AnnotationManager(project)
+    
+    input_file = os.path.join(DATA,input_file)
+    
+    input_annotations = pd.read_csv("examples/valid_raw_data/annotations/input.csv")
+    
+    am.import_annotations(input_annotations)
+    am.read()
+    
+    assert (
+        am.annotations.shape[0] == input_annotations.shape[0]
+    ), "first importation did not complete successfully"
+    
+    second_input = pd.read_csv(input_file)
+    
+    if exception is not None:
+        with pytest.raises(exception):
+            am.import_annotations(second_input, overwrite_existing=ow)
+    else:
+        imported, errors = am.import_annotations(second_input, overwrite_existing=ow)
+        
+        if rimported is not None:
+            rimported = os.path.join(TRUTH, rimported)
+            #imported.to_csv(rimported, index=False)
+            rimported = pd.read_csv(rimported)
+            pd.testing.assert_frame_equal(rimported.reset_index(drop=True),
+                                          imported.drop(['imported_at','package_version'],axis=1).reset_index(drop=True),
+                                          check_like=True,
+                                          check_dtype=False)
+        
+        if rerrors is not None:
+            rerrors = os.path.join(TRUTH, rerrors)
+            #errors.to_csv(rerrors, index=False)
+            rerrors = pd.read_csv(rerrors)
+            pd.testing.assert_frame_equal(rerrors.reset_index(drop=True),
+                                          errors.drop(['imported_at','package_version'],axis=1).reset_index(drop=True),
+                                          check_like=True,
+                                          check_dtype=False)
+            
+        #raise Exception()
+            
+        am.read()
+        assert all(
+            [
+                os.path.exists(
+                    os.path.join(
+                        project.path,
+                        "annotations",
+                        a["set"],
+                        "converted",
+                        a["annotation_filename"],
+                    )
+                )
+                for a in am.annotations.to_dict(orient="records")
+            ]
+        ), "some annotations are missing"
+        
+        errors, warnings = am.validate()
+        assert len(errors) == 0 and len(warnings) == 0, "malformed annotations detected"
+        
+        errors, warnings = am.read()
+        assert len(errors) == 0 and len(warnings) == 0, "malformed annotation indexes detected"
 
 
 def test_intersect(project):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -133,7 +133,22 @@ def test_its(its):
         os.path.join("tests/truth/its", "{}_ITS_Segments.csv".format(its)), dtype={'recordingInfo':'object'}
     )  # .fillna('NA')
     check_its(converted, truth)
+    
+@pytest.mark.parametrize("nline,column,value,exception,error", 
+                         [(0,'range_onset',-10,AssertionError,"range_onset must be greater or equal to 0"),
+                         (3,'range_offset',1970000,AssertionError,"range_offset must be greater than range_onset"),
+                         ])
+def test_rejected_imports(project, nline, column, value, exception, error):
+    am = AnnotationManager(project)
 
+    input_annotations = pd.read_csv("examples/valid_raw_data/annotations/input.csv")
+    
+    input_annotations.iloc[nline, input_annotations.columns.get_loc(column)] = value
+    
+    print(input_annotations[['range_onset','range_offset']])
+    
+    with pytest.raises(exception, match=error):
+        am.import_annotations(input_annotations)
 
 def test_import(project):
     am = AnnotationManager(project)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ Created on Wed Jul 27 11:23:05 2022
 import pytest
 
 from ChildProject.projects import ChildProject
-from ChildProject.utils import series_to_datetime, time_intervals_intersect, intersect_ranges, TimeInterval, get_audio_duration
+from ChildProject.utils import series_to_datetime, time_intervals_intersect, intersect_ranges, TimeInterval, get_audio_duration, find_lines_involved_in_overlap
 import pandas as pd
 import datetime
 import os
@@ -69,6 +69,21 @@ AUDIOS = os.path.join('examples','valid_raw_data','recordings','raw')
 def test_get_audio_duration(file, result):
     
     assert result == get_audio_duration(file)
+    
+INP_CSV = os.path.join('examples','valid_raw_data','annotations','input.csv')
+@pytest.mark.parametrize('file,result,labels',
+    [(INP_CSV, [], ['set', 'recording_filename']),
+     (INP_CSV, [0,1,2,3,4,5,6,7,8,9], []),
+     (INP_CSV, [3,4,8,9], ['set']),
+    ])
+def test_find_lines_involved_in_overlaps(file, result, labels):
+    
+    df = pd.read_csv(file)
+    truth = df.iloc[result]
+    
+    df_no_ov = df[find_lines_involved_in_overlap(df, 'range_onset', 'range_offset', labels)]
+    
+    pd.testing.assert_frame_equal(df_no_ov, truth, check_like = True)
     
     
     

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 from ChildProject.projects import ChildProject
+from ChildProject.annotations import AnnotationManager
 import os
-
 
 def test_valid_project():
     path = os.path.normpath("examples/valid_raw_data")
@@ -14,12 +14,20 @@ def test_valid_project():
 def test_invalid_project():
     project = ChildProject("examples/invalid_raw_data")
     errors, warnings = project.validate()
+    
+    am = AnnotationManager(project)
+    
+    errors.extend(am.errors)
+    warnings.extend(am.warnings)
 
     expected_errors = [
         os.path.normpath("examples/invalid_raw_data/metadata/children.csv")+ ": child_id '1' appears 2 times in lines [2,3], should appear once",
         "cannot find recording 'test_1_20200918.mp3' at "+os.path.normpath("'examples/invalid_raw_data/recordings/raw/test_1_20200918.mp3'"),
         os.path.normpath("examples/invalid_raw_data/metadata/recordings.csv")+ ": 'USB' is not a permitted value for column 'recording_device_type' on line 2, should be any of [lena,usb,olympus,babylogger,unknown]",
-        "Age at recording is negative in recordings on line 3 (-15.4 months). Check date_iso for that recording and child_dob for the corresponding child."
+        "Age at recording is negative in recordings on line 3 (-15.4 months). Check date_iso for that recording and child_dob for the corresponding child.",
+        "duplicate reference to annotations/vtc_rttm/converted/sound_1980000_1990000.csv (appears 2 times)",
+        "overlaps in the annotation index for the following [set, annotation_filename] list: [['textgrid', 'sound_0_10000.csv'], ['textgrid', 'sound_0_300000.csv'], ['textgrid', 'sound_0_40000000.csv'], ['vtc_rttm', 'sound_1980000_1990000.csv'], ['vtc_rttm', 'sound_1980000_1990000.csv']]",
+        "annotation index does not verify range_offset > range_onset >= 0 for set <ranges>, annotation filename <sound_0_300000.csv>",
     ]
 
     expected_warnings = [

--- a/tests/truth/err_overlap.csv
+++ b/tests/truth/err_overlap.csv
@@ -1,4 +1,3 @@
 set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
-textgrid,sound.wav,0,example.TextGrid,0,5000,TextGrid,,"importation for set <textgrid> recording <sound.wav> from 0 to 5000 cannot continue because it overlaps with these existing annotation lines: 
-[('textgrid', 'sound.wav', 0, 10000)]",
+textgrid,sound.wav,0,example.TextGrid,0,5000,TextGrid,,"importation for set <textgrid> recording <sound.wav> from 0 to 5000 cannot continue because it overlaps with these existing annotation lines: [('textgrid', 'sound.wav', 0, 10000)]",
 eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,"annotation file annotations/eaf_basic/converted/sound_0_300000.csv already exists, to reimport it, use the overwrite_existing flag",

--- a/tests/truth/err_overlap.csv
+++ b/tests/truth/err_overlap.csv
@@ -1,7 +1,4 @@
 set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
 textgrid,sound.wav,0,example.TextGrid,0,5000,TextGrid,,"importation for set <textgrid> recording <sound.wav> from 0 to 5000 cannot continue because it overlaps with these existing annotation lines: 
-        set recording_filename  time_seek  ...  package_version  error merged_from
-2  textgrid          sound.wav          0  ...            0.0.7    NaN         NaN
-
-[1 rows x 13 columns]",
+[('textgrid', 'sound.wav', 0, 10000)]",
 eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,"annotation file annotations/eaf_basic/converted/sound_0_300000.csv already exists, to reimport it, use the overwrite_existing flag",

--- a/tests/truth/err_overlap.csv
+++ b/tests/truth/err_overlap.csv
@@ -1,0 +1,7 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
+textgrid,sound.wav,0,example.TextGrid,0,5000,TextGrid,,"importation for set <textgrid> recording <sound.wav> from 0 to 5000 cannot continue because it overlaps with these existing annotation lines: 
+        set recording_filename  time_seek  ...  package_version  error merged_from
+2  textgrid          sound.wav          0  ...            0.0.7    NaN         NaN
+
+[1 rows x 13 columns]",
+eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,"annotation file annotations/eaf_basic/converted/sound_0_300000.csv already exists, to reimport it, use the overwrite_existing flag",

--- a/tests/truth/err_reimport_no_ow.csv
+++ b/tests/truth/err_reimport_no_ow.csv
@@ -1,0 +1,10 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
+textgrid,sound.wav,0,example.TextGrid,0,10000,TextGrid,,"annotation file annotations/textgrid/converted/sound_0_10000.csv already exists, to reimport it, use the overwrite_existing flag",
+eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,"annotation file annotations/eaf_basic/converted/sound_0_300000.csv already exists, to reimport it, use the overwrite_existing flag",
+eaf_solis,sound.wav,0,example_solis.eaf,0,40000000,eaf,,"annotation file annotations/eaf_solis/converted/sound_0_40000000.csv already exists, to reimport it, use the overwrite_existing flag",
+vtc_rttm,sound.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,"annotation file annotations/vtc_rttm/converted/sound_1980000_1990000.csv already exists, to reimport it, use the overwrite_existing flag",
+alice,sound.wav,0,example_alice.txt,1980000,1990000,alice,namibie_aiku_20160714_1,"annotation file annotations/alice/converted/sound_1980000_1990000.csv already exists, to reimport it, use the overwrite_existing flag",
+metrics,sound.wav,0,example_metrics.rttm,0,100000000,vtc_rttm,tsimane2017_C01_20170706,"annotation file annotations/metrics/converted/sound_0_100000000.csv already exists, to reimport it, use the overwrite_existing flag",
+old_its,sound.wav,0,example_lena_old.its,0,100000000,its,,"annotation file annotations/old_its/converted/sound_0_100000000.csv already exists, to reimport it, use the overwrite_existing flag",
+new_its,sound.wav,0,example_lena_new.its,0,100000000,its,,"annotation file annotations/new_its/converted/sound_0_100000000.csv already exists, to reimport it, use the overwrite_existing flag",
+vtc_rttm,sound2.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,"annotation file annotations/vtc_rttm/converted/sound2_1980000_1990000.csv already exists, to reimport it, use the overwrite_existing flag",

--- a/tests/truth/imp_overlap.csv
+++ b/tests/truth/imp_overlap.csv
@@ -1,0 +1,4 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
+eaf_solis,sound.wav,0,example_solis.eaf,40000000,80000000,eaf,,,sound_40000000_80000000.csv
+textgrid,sound2.wav,0,example.TextGrid,0,10000,TextGrid,,,sound2_0_10000.csv
+textgrid2,sound.wav,0,example.TextGrid,0,10000,TextGrid,,,sound_0_10000.csv

--- a/tests/truth/imp_reimport_no_ow.csv
+++ b/tests/truth/imp_reimport_no_ow.csv
@@ -1,0 +1,2 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,error,annotation_filename
+alice,sound2.wav,0,example_alice.txt,1990000,2000000,alice,namibie_aiku_20160714_1,,sound2_1990000_2000000.csv

--- a/tests/truth/imp_reimport_ow.csv
+++ b/tests/truth/imp_reimport_ow.csv
@@ -1,0 +1,11 @@
+set,recording_filename,time_seek,raw_filename,range_onset,range_offset,format,filter,annotation_filename
+textgrid,sound.wav,0,example.TextGrid,0,10000,TextGrid,,sound_0_10000.csv
+eaf_basic,sound.wav,0,example.eaf,0,300000,eaf,,sound_0_300000.csv
+eaf_solis,sound.wav,0,example_solis.eaf,0,40000000,eaf,,sound_0_40000000.csv
+vtc_rttm,sound.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,sound_1980000_1990000.csv
+alice,sound.wav,0,example_alice.txt,1980000,1990000,alice,namibie_aiku_20160714_1,sound_1980000_1990000.csv
+metrics,sound.wav,0,example_metrics.rttm,0,100000000,vtc_rttm,tsimane2017_C01_20170706,sound_0_100000000.csv
+old_its,sound.wav,0,example_lena_old.its,0,100000000,its,,sound_0_100000000.csv
+new_its,sound.wav,0,example_lena_new.its,0,100000000,its,,sound_0_100000000.csv
+vtc_rttm,sound2.wav,0,example.rttm,1980000,1990000,vtc_rttm,namibie_aiku_20160714_1,sound2_1980000_1990000.csv
+alice,sound2.wav,0,example_alice.txt,1990000,2000000,alice,namibie_aiku_20160714_1,sound2_1990000_2000000.csv


### PR DESCRIPTION
The purpose of the PR is to enforce that:
- we cannot have multiple lines in annotations.csv with the same set and annotation_filename
- A set cannot have overlapping annotation files. Meaning inside a specific set, it is not possible to annotate multiple times the same stretch of audio (bc then this stretch is counted multiple times in metrics and other analysis)

To achieve this, all the functions that interact with annotations.csv must make sure before writing to it that those cases don't exist,
this is especially relevant for importations that now will fail for every row that does not satisfy those conditions.

Previously, the errors encountered during importation would find themselves recorded into annotations.csv. I felt like this could be troublesome as the file is intended as a record of indexed annotation and should not serve as a logfile. My take was to output all the errors to a separate csv in extra but not too sure about this solution