### PR TITLE
Recording devices/add

### DIFF
--- a/ChildProject/converters.py
+++ b/ChildProject/converters.py
@@ -109,6 +109,7 @@ class VtcConverter(AnnotationConverter):
                 "conf",
                 "unk",
             ],
+            dtype={'type': str, "file" : str, 'stype':str}
         )
 
         n_recordings = len(rttm["file"].unique())

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -177,9 +177,9 @@ class ChildProject:
         ),
         IndexColumn(
             name="recording_device_type",
-            description="lena, usb, olympus, babylogger (lowercase)",
+            description="lena, usb, olympus, babylogger (lowercase), izyrec",
             required=True,
-            choices=["lena", "usb", "olympus", "babylogger", "unknown"],
+            choices=["lena", "usb", "olympus", "babylogger", "izyrec", "unknown"],
         ),
         IndexColumn(
             name="recording_filename",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,7 +22,7 @@ def test_invalid_project():
 
     expected_errors = [
         os.path.normpath("examples/invalid_raw_data/metadata/children.csv")+ ": child_id '1' appears 2 times in lines [2,3], should appear once",
-        os.path.normpath("examples/invalid_raw_data/metadata/recordings.csv")+ ": 'USB' is not a permitted value for column 'recording_device_type' on line 2, should be any of [lena,usb,olympus,babylogger,unknown]",
+        os.path.normpath("examples/invalid_raw_data/metadata/recordings.csv")+ ": 'USB' is not a permitted value for column 'recording_device_type' on line 2, should be any of [lena,usb,olympus,babylogger,izyrec,unknown]",
         "cannot find recording 'test_1_20200918.mp3' at "+os.path.normpath("'examples/invalid_raw_data/recordings/raw/test_1_20200918.mp3'"),
         "cannot find recording 'test_1_is_not_here.wav' at "+os.path.normpath("'examples/invalid_raw_data/recordings/raw/test_1_is_not_here.wav'"), 
         'Age at recording is negative in recordings on line 3 (-15.4 months). Check date_iso for that recording and child_dob for the corresponding child.', 


### PR DESCRIPTION
add izyrec as a possible choice of recording device
fix a bug where filtering a rttm that has filenames using only digits in the name would result in the filter failing