### PR TITLE
Conda Mac Python version upgrade

### DIFF
--- a/env_macos.yml
+++ b/env_macos.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.10
   - ffmpeg
   - pip
   - pytest


### PR DESCRIPTION
Supporting ARM Macs by default without Rosetta