### PR TITLE
Annotations/outdated missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - docs and tests for init command
 - docs and tests for automated-import command
 
+### Fixed
+
+- does not fail anymore when annotations are missing their merged_from set
+
 ## [0.2.2] 2024-06-26
 
 ### Added

--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -455,10 +455,16 @@ class AnnotationManager:
                 for j in row['merged_from'].split(','):
                     #if a list of sets was given and the set is not in that list, skip it
                     if (sets is not None and j in sets) or sets is None:
-                        if row['imported_at'] < last_modif[j]:
-                            warnings.append("set {} is outdated because the {} set it is merged from was modified. Consider updating or rerunning the creation of the {} set.".format(i,j,i))
+                        if j not in last_modif:
+                            warnings.append("set {} was originally derived from set {} which does not exist anymore.\
+                             Consider adding the set {} or updating the information.".format(i,j,j))
+                        else:
+                            if row['imported_at'] < last_modif[j]:
+                                warnings.append("set {} is outdated because the {} set it is merged from was modified.\
+                                 Consider updating or rerunning the creation of the {} set.".format(i,j,i))
                         
         return warnings
+
     def _import_annotation(
         self, import_function: Callable[[str], pd.DataFrame],
         params: dict,


### PR DESCRIPTION
fixes instances when annotations were derived or merged from other sets, and then the original sets were removed, this would lead to the checks that are conducted to check if the derived sets are outdated failing