### PR TITLE
Docs/rework installation

### DIFF
--- a/ChildProject/annotations.py
+++ b/ChildProject/annotations.py
@@ -636,12 +636,11 @@ class AnnotationManager:
         dataset in the correct spot given the set it belongs to.
         The destination file can contain parent folders, which will be included in the copied file (e.g. src_path=
         "/home/user/tmp/myrec.rttm", dst_file="loc1/RA5/rec001.rttm", set='vtc' ; will copy the file inside
-         the dataset in a annotations/vtc/raw/loc1/RA5 folder, the file will be named rec001.rttm.
+        the dataset in a annotations/vtc/raw/loc1/RA5 folder, the file will be named rec001.rttm.
 
         :param src_path: path on the system to the annotation file to add to the dataset
         :type src_path: Path | str
-        :param dst_file: filename as it will be stored in the dataset, with possible parent folders (e.g.
-        'location1/RA5/rec004.rttm' will copy the original file as rec004.rttm inside folders location1 -> RA5)
+        :param dst_file: filename as it will be stored in the dataset, with possible parent folders (e.g. 'location1/RA5/rec004.rttm' will copy the original file as rec004.rttm inside folders location1 -> RA5)
         :type dst_file: Path | str
         :param set: annotation set the annotation file belongs to
         :type set: str
@@ -672,8 +671,7 @@ class AnnotationManager:
         be in the file name as a posix path (i.e. subfolder/file)
         The set parameter is meant to define what annotation set the raw file is stored in.
 
-        :param file: filename as it is stored in the dataset annotations, in the annotation set raw folder (e.g. set=vtc
-        will be evaluated inside the annotations/vtc/raw folder of the dataset
+        :param file: filename as it is stored in the dataset annotations, in the annotation set raw folder (e.g. set=vtc will be evaluated inside the annotations/vtc/raw folder of the dataset
         :type file: Path | str
         :param set: name of the annotation set the file is stored in.
         :type set: str
@@ -1036,7 +1034,7 @@ class AnnotationManager:
         for warning in outdated_sets:
             logger_annotations.warning("warning: %s", warning)
 
-        return (imported, errors)
+        return imported, errors
 
     def _derive_annotation(
             self,

--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -432,15 +432,13 @@ class ChildProject:
         the correct spot depending on the file type.
         The destination file can contain parent folders, which will be included in the copied file (e.g. src_path=
         "/home/user/tmp/myrec.wav", dst_file="loc1/RA5/rec001.wav", file_type='recording' ; will copy the file inside
-         the dataset in a recordings/raw/loc1/RA5 folder, the file will be named rec001.wav.
+        the dataset in a recordings/raw/loc1/RA5 folder, the file will be named rec001.wav.
 
         :param src_path: path to the file to add to the dataset on the system
         :type src_path: Path | str
-        :param dst_file: filename as it will be stored in the dataset, with possible subfolder(s) (e.g.
-        "location1/RA5/rec004.wav will copy the original file as rec004.wav inside folders location1 -> RA5)
+        :param dst_file: filename as it will be stored in the dataset, with possible subfolder(s) (e.g. "location1/RA5/rec004.wav will copy the original file as rec004.wav inside folders location1 -> RA5)
         :type dst_file: Path | str
-        :param file_type: type of the file to copy in order to know where it should be stored in the dataset, choose any
-        of 'recording','metadata','extra' or 'raw', raw is just copied from the root of the dataset into any folder
+        :param file_type: type of the file to copy in order to know where it should be stored in the dataset, choose any of 'recording','metadata','extra' or 'raw', raw is just copied from the root of the dataset into any folder
         :type file_type: str
         :param overwrite: overwrite the existing destination if it already exists
         :type overwrite: bool, optional
@@ -482,8 +480,7 @@ class ChildProject:
         :param file: filename as it is stored in the dataset, in the tree of its category (e.g. recordings names are
         evaluated inside the recordings/raw folder of the dataset
         :type file: Path | str
-        :param file_type: type of the file to copy in order to know where it should be stored in the dataset, choose any
-        of 'recording','metadata','extra' or 'raw', raw is just copied from the root of the dataset into any folder
+        :param file_type: type of the file to copy in order to know where it should be stored in the dataset, choose any of 'recording','metadata','extra' or 'raw', raw is just copied from the root of the dataset into any folder
         :type file_type: str
         """
         file_path = Path(file)

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -8,6 +8,9 @@
 .highlight-bash > .highlight{
 	background: #edf4f9;
 }
+.highlight-powershell > .highlight{
+	background: #edf4f9;
+}
 
 .sphinx-tabs-tab {
   font-size: 13px;

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,25 +1,120 @@
 .. _installation:
 
-Installation
-------------
+ChildProject is a python package distributed through `pypi https://pypi.org/project/ChildProject/`__. It is meant to
+function in conjunction with multiple dependency packages, both python packages and system packages. This is why we
+advise users to install all of those in a self-contained conda environment, this will ensure separation between your
+system and the software used in projects using ChildProject. You can choose to install ChildProject on its own,
+but be aware that some features may fail or be unavailable if some system packages used by ChildProject are missing.
 
-The following instructions will let you install two python packages:
+Installation in a conda environment
+-----------------------------------
+
+The following instructions will let you install the following packages inside a self-contained conda environment:
 
  - **ChildProject**, the package that is documented here, follow the main installation instructions to get it
  - **DataLad**, a python software for the management and delivery of scientific data. Although ChildProject may work without it, a number of datasets of daylong recordings of children require it. We advise to work with it alongside ChildProject. Follow the instructions in the section "Datalad installation" to get it as well.
 
-.. note::
+This installation procedure requires a package able to handle conda environments. We recommend using `micromamba <https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html>`__
+but you can use any alternative. A very common alternative is anaconda (conda command). If you are not sure you have conda or
+micromamba installed, check the :ref:`environment_manager_section`.
 
-    The default installation procedure requires anaconda. If you are not sure you have conda installed, please do ``conda --version``.
-    If you don't, please refer to the instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__.
+.. warning::
 
-Linux users
+    All our instructions use ``micromamba`` commands, if you are using a difference environment manager, such as anaconda
+    , replace all instructions with the proper command (``conda`` for example).
+
+Automatic install
+~~~~~~~~~~~~~~~~~
+
+Linux / MacOS
+*************
+
+To install automatically in Linux, MacOS run in a terminal
+
+.. code:: bash
+
+    "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
+
+
+Windows
+*******
+
+To install automatically in Windows, open a powershell prompt as administrator and run
+
+.. code:: powershell
+
+    Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.ps1 -UseBasicParsing).Content)
+
+Manual install
+~~~~~~~~~~~~~~
+
+Linux Users
+***********
+
+.. code:: bash
+
+    # download the conda environment
+    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_linux.yml -o env.yml
+
+    # create the conda environment
+    micromamba env create -f env.yml
+
+    # activate the environment (this should be done systematically to use our package)
+    micromamba activate childproject
+
+
+MacOS users
+***********
+
+.. code:: bash
+
+    # download the conda environment
+    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
+
+    # create the conda environment
+    micromamba env create -f env.yml
+
+    # activate the environment (this should be done systematically to use our package)
+    micromamba activate childproject
+
+    # install git-annex from brew
+    brew install git-annex
+
+
+Windows users
+*************
+
+.. code:: powershell
+
+    # download the conda environment
+    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_windows.yml -o env.yml
+
+Usage inside the environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To use the package, we need the created environment to be active. This step is needed everytime a new terminal is open.
+To activate en environment, use you environment manager and the activate subcommand. For example with micromamba:
+
+.. code:: bash
+
+    # activate the environment
+    micromamba activate childproject
+
+
+Installation in the system packages
+-----------------------------------
+
+This installation is not recommended, this won't allow you to clearly separate your python packages depending on projects
+and will require packages at the system level to be installed (meaning you would need administrator permissions) such as
+sox and ffmpeg
+
+Linux Users
 ~~~~~~~~~~~
 
 .. code:: bash
 
     # download the conda environment
-    wget https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_linux.yml -O env.yml
+    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
 
     # create the conda environment
     conda env create -f env.yml
@@ -27,6 +122,8 @@ Linux users
     # activate the environment (this should be done systematically to use our package)
     conda activate childproject
 
+    # install git-annex from brew
+    brew install git-annex
 
 MacOS users
 ~~~~~~~~~~~
@@ -45,17 +142,6 @@ MacOS users
     # install git-annex from brew
     brew install git-annex
 
-.. note::
-
-    The ChildProject package alone can also be installed directly through pip, without using conda.
-    However, this means git-annex, ffmpeg, and other dependencies that are not installable
-    through pip will have to be installed by hand.
-
-    The following command will install the python package alone via pip and pypi:
-
-    .. code:: bash
-
-        pip install ChildProject
 
 Windows users
 ~~~~~~~~~~~~~
@@ -65,9 +151,6 @@ Windows users
     ChildProject is only officially supported on Linux and Mac for python >= 3.7.
     We perform automated, continuous testing on these environments to look
     for potential issues at any step of the development.
-
-    We expect the package to work on Windows, although we do not perform
-    automated tests on this OS at the moment.
 
     If you are on a Windows system, consider using a `Windows subsystem for linux (WSL) <https://docs.microsoft.com/en-us/windows/wsl/install>`__,
     inside of which you can use all the Linux instructions while accessing your windows filesystem.
@@ -191,6 +274,13 @@ Each --version command should output the version of the package
     DataLad can also be upgraded with ``pip install datalad --upgrade``
     (see DataLad's documentation for more details).
 
+Check and or install Anaconda / Micromamba
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+please run ``conda --version`` and ``micromamba --version``.
+To install micromamba follow instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`__.
+To install conda follow instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__.
+
 Troubleshooting
 ~~~~~~~~~~~~~~~
 
@@ -198,7 +288,7 @@ If you are having trouble installing ChildProject, please look
 for similar issues on our GithHub (in `Issues <https://github.com/LAAC-LSCP/ChildProject/issues>`__ or `Discussions <https://github.com/LAAC-LSCP/ChildProject/discussions>`__).
 
 If this issue is related to a dependency of the package, we recommend that you ask
-the developers of the depdendency directly as you may get more accurate advice.
+the developers of the dependency directly as you may get more accurate advice.
 
 If this issue is related to DataLad, please create an issue on `DataLad's GitHub <https://github.com/datalad/datalad/issues>`__.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -26,228 +26,218 @@ micromamba installed, check the :ref:`environment_manager_section`.
 Automatic install
 ~~~~~~~~~~~~~~~~~
 
-Linux / MacOS
-*************
+Reminder, for running the automatic install, you need an :ref:`environment_manager_section` environment manager to be installed
 
-To install automatically in Linux, MacOS run in a terminal
+.. tabs::
 
-.. code:: bash
+   .. group-tab:: linux
 
-    "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
+      To install automatically in Linux run in a terminal
 
+      .. code-block:: bash
 
-Windows
-*******
+         "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
 
-To install automatically in Windows, open a powershell prompt as administrator and run
+   .. group-tab:: MacOS
 
-.. code:: powershell
+      To install automatically in MacOS run in a terminal
 
-    Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.ps1 -UseBasicParsing).Content)
+      .. code-block:: bash
+
+         "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
+
+   .. group-tab:: Windows
+
+      To install automatically in Linux, MacOS run in a terminal
+
+      .. code-block:: powershell
+
+         Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.ps1 -UseBasicParsing).Content)
+
 
 Manual install
 ~~~~~~~~~~~~~~
 
-Linux Users
-***********
+.. tabs::
 
-.. code:: bash
+   .. group-tab:: linux
 
-    # download the conda environment
-    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_linux.yml -o env.yml
+      .. code-block:: bash
 
-    # create the conda environment
-    micromamba env create -f env.yml
+        # download the conda environment
+        curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_linux.yml -o env.yml
 
-    # activate the environment (this should be done systematically to use our package)
-    micromamba activate childproject
+        # create the conda environment
+        micromamba env create -f env.yml
 
+        # activate the environment (this should be done systematically to use our package)
+        micromamba activate childproject
 
-MacOS users
-***********
+   .. group-tab:: MacOS
 
-.. code:: bash
+      .. code-block:: bash
 
-    # download the conda environment
-    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
+         # download the conda environment
+         curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
 
-    # create the conda environment
-    micromamba env create -f env.yml
+         # create the conda environment
+         micromamba env create -f env.yml
 
-    # activate the environment (this should be done systematically to use our package)
-    micromamba activate childproject
+         # activate the environment (this should be done systematically to use our package)
+         micromamba activate childproject
 
-    # install git-annex from brew
-    brew install git-annex
+         # install git-annex from brew
+         brew install git-annex
 
+   .. group-tab:: Windows
 
-Windows users
-*************
+      .. code-block:: powershell
 
-.. code:: powershell
+         # download the conda environment
+         curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_windows.yml -o env.yml
 
-    # download the conda environment
-    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_windows.yml -o env.yml
+         # create the conda environment
+         micromamba env create -f env.yml
 
-Usage inside the environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         # activate the environment (this should be done systematically to use our package)
+         micromamba activate childproject
 
-To use the package, we need the created environment to be active. This step is needed everytime a new terminal is open.
-To activate en environment, use you environment manager and the activate subcommand. For example with micromamba:
-
-.. code:: bash
-
-    # activate the environment
-    micromamba activate childproject
+         # install git-annex using uv tool
+         uv tool install git-annex
 
 
 Installation in the system packages
 -----------------------------------
 
-This installation is not recommended, this won't allow you to clearly separate your python packages depending on projects
-and will require packages at the system level to be installed (meaning you would need administrator permissions) such as
-sox and ffmpeg
+Installing directly into the system is not recommended for non admins and beginners. This won't clearly separate your
+ python packages depending on projects and will require packages at the system level to be installed
+ (requiring administrator permissions) such as sox and ffmpeg.
 
-Linux Users
-~~~~~~~~~~~
+.. tabs::
 
-.. code:: bash
+   .. group-tab:: linux
 
-    # download the conda environment
-    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
+      Make sure you have a recent version of python installed or install it (https://www.python.org/)
 
-    # create the conda environment
-    conda env create -f env.yml
+      Installing packages on Debian
 
-    # activate the environment (this should be done systematically to use our package)
-    conda activate childproject
+      .. code-block:: bash
 
-    # install git-annex from brew
-    brew install git-annex
+        sudo apt-get install sox ffmpeg git git-annex
 
-MacOS users
-~~~~~~~~~~~
+      Installing packages on Fedora/RHEL/CentOS/Rocky
 
-.. code:: bash
+      .. code-block:: bash
 
-    # download the conda environment
-    curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
+        sudo yum install sox ffmpeg git git-annex
 
-    # create the conda environment
-    conda env create -f env.yml
+      Installing packages on Arch
 
-    # activate the environment (this should be done systematically to use our package)
-    conda activate childproject
+      .. code-block:: bash
 
-    # install git-annex from brew
-    brew install git-annex
+        sudo pacman -S install sox ffmpeg git git-annex
 
 
-Windows users
-~~~~~~~~~~~~~
+      Then python packages can be installed with pip directly (or alternatives like uv)
 
-.. warning::
+      .. code-block:: bash
 
-    ChildProject is only officially supported on Linux and Mac for python >= 3.7.
-    We perform automated, continuous testing on these environments to look
-    for potential issues at any step of the development.
+        pip install -U datalad ChildProject
 
-    If you are on a Windows system, consider using a `Windows subsystem for linux (WSL) <https://docs.microsoft.com/en-us/windows/wsl/install>`__,
-    inside of which you can use all the Linux instructions while accessing your windows filesystem.
+   .. group-tab:: MacOS
 
-If you which to continue using directly Windows, you must do the following:
- 1. Download and run the Git installer found in `this page <https://git-scm.com/download/win>`__, use the first link in the page. When running the installer, we advise you keep all the default choices.
- 
- .. figure:: images/git-install.png
-    :height: 300
-    :alt: git installer Wizard
+      Make sure you have a recent version of python installed or install it (https://www.python.org/)
 
-    git installer
+      .. code-block:: bash
 
- 2. Download and run the git-annex installer found `here <https://downloads.kitenet.net/git-annex/windows/current/>`__, download the file 'git-annex-installer.exe' and then launch it, keep everything as default.
- 
- .. figure:: images/git-annex-install.png
-    :height: 300
-    :alt: git annex installer Wizard
+         # install via brew, git should be installed by default
+         brew install sox ffmpeg git-annex
 
-    git annex installer
+         pip install -U datalad ChildProject
 
- 3. Download and run the `Miniconda installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`__, launch the installer and keep all the default options.
- 
- .. figure:: images/miniconda-install.png
-    :height: 300
-    :alt: miniconda installer Wizard
+   .. group-tab:: Windows
 
-    miniconda installer
+     1. Download and run the Git installer found in `this page <https://git-scm.com/download/win>`__, use the first link in the page. When running the installer, we advise you keep all the default choices.
 
- 4. Open an Anaconda prompt, after all the installations, you should now have a program called "Anaconda Prompt" in your start Menu, if you can't find it, use the search field. You will use this program whenever you use ChilProject so it is probably best to pin it to the start menu or create a shortcut on your desktop. Launch it, you should be presented with a terminal window, allowing you to enter and launch commands
- 
- .. figure:: images/anaconda-prompt.png
-    :alt: Anaconda prompt cmd
+     .. figure:: images/git-install.png
+        :height: 300
+        :alt: git installer Wizard
 
-    Anaconda prompt
+        git installer
 
- 5. Use the following command to download the environment description
+     2. Download and run the git-annex installer found `here <https://downloads.kitenet.net/git-annex/windows/current/>`__, download the file 'git-annex-installer.exe' and then launch it, keep everything as default.
 
- .. code:: bash
+     .. figure:: images/git-annex-install.png
+        :height: 300
+        :alt: git annex installer Wizard
 
-     # download the conda environment creation info
-     curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
+        git annex installer
 
- 
- .. figure:: images/download-yml.png
-    :alt: download environment description file
+     3. Download and run the `Miniconda installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`__, launch the installer and keep all the default options.
 
-    download the conda environment description file
+     .. figure:: images/miniconda-install.png
+        :height: 300
+        :alt: miniconda installer Wizard
 
- 6. Run this line to create the conda environment, keep the default parameters, this can take several minutes 
+        miniconda installer
 
- .. code:: bash
+     4. Open an Anaconda prompt, after all the installations, you should now have a program called "Anaconda Prompt" in your start Menu, if you can't find it, use the search field. You will use this program whenever you use ChilProject so it is probably best to pin it to the start menu or create a shortcut on your desktop. Launch it, you should be presented with a terminal window, allowing you to enter and launch commands
 
-     # create the conda environment, keep the default parameters, this may take a long time
-     conda env create -f env.yml
- 
- .. figure:: images/env-install.png
-    :alt: creation of conda environment
+     .. figure:: images/anaconda-prompt.png
+        :alt: Anaconda prompt cmd
 
-    creation of the environment
+        Anaconda prompt
 
- 7. Activate the childproject environment in your Anaconda Prompt. This must be done everytime you use childproject
+     5. Use the following command to download the environment description
 
- .. code:: bash
+     .. code:: bash
 
-     # activate the environment (this should be done systematically to use the package)
-     conda activate childproject
- 
- .. figure:: images/env-activate.png
-    :alt: activate the childproject environment
+         # download the conda environment creation info
+         curl https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_macos.yml -o env.yml
 
-    activate the newly created environment, to do every time we launch a new anaconda prompt
 
-Congratulations, You are now able to use all the childproject features inside your Anaconda Prompt.
+     .. figure:: images/download-yml.png
+        :alt: download environment description file
 
-Datalad installation
-~~~~~~~~~~~~~~~~~~~~
+        download the conda environment description file
 
-This section is optional, it will help you to install Datalad once you have completed the previous step of installing ChildProject.
+     6. Run this line to create the conda environment, keep the default parameters, this can take several minutes
 
-If you followed the previous instructions correctly, you should have created and activated a conda environment with ChildProject installed. When you are in this environment, run the following:
+     .. code:: bash
 
-.. code:: bash
+         # create the conda environment, keep the default parameters, this may take a long time
+         conda env create -f env.yml
 
-     # install datalad in your environment
-     pip install datalad
+     .. figure:: images/env-install.png
+        :alt: creation of conda environment
+
+        creation of the environment
+
+     7. Activate the childproject environment in your Anaconda Prompt. This must be done everytime you use childproject
+
+     .. code:: bash
+
+         # activate the environment (this should be done systematically to use the package)
+         conda activate childproject
+
+     .. figure:: images/env-activate.png
+        :alt: activate the childproject environment
+
+        activate the newly created environment, to do every time we launch a new anaconda prompt
+
+    Congratulations, You are now able to use all the childproject features inside your Anaconda Prompt.
 
 
 Check the setup
 ~~~~~~~~~~~~~~~
 
 You can now make sure the packages have been successfully installed:
-Each --version command should output the version of the package
+Each --version command should output the version of the package.
+If you installed in an environment, check it is activated or activate it
 
 .. clidoc::
 
-   child-project --help
+   child-project --version
 
 .. clidoc::
 
@@ -277,9 +267,14 @@ Each --version command should output the version of the package
 Check and or install Anaconda / Micromamba
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-please run ``conda --version`` and ``micromamba --version``.
-To install micromamba follow instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`__.
-To install conda follow instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__.
+To check if conda or micromamba is installed, run in a terminal or powershell the following commands :
+``conda --version`` and ``micromamba --version``
+
+If either print a version number, they are installed and you should be able to use them.
+
+If none is installed, refe to the installation instructions:
+ - micromamba follow instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`__.
+ - conda follow instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__.
 
 Troubleshooting
 ~~~~~~~~~~~~~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,6 +1,9 @@
 .. _installation:
 
-ChildProject is a python package distributed through `pypi https://pypi.org/project/ChildProject/`__. It is meant to
+Installation
+============
+
+ChildProject is a python package distributed through `pypi <https://pypi.org/project/ChildProject>`__. It is meant to
 function in conjunction with multiple dependency packages, both python packages and system packages. This is why we
 advise users to install all of those in a self-contained conda environment, this will ensure separation between your
 system and the software used in projects using ChildProject. You can choose to install ChildProject on its own,
@@ -11,8 +14,8 @@ Installation in a conda environment
 
 The following instructions will let you install the following packages inside a self-contained conda environment:
 
- - **ChildProject**, the package that is documented here, follow the main installation instructions to get it
- - **DataLad**, a python software for the management and delivery of scientific data. Although ChildProject may work without it, a number of datasets of daylong recordings of children require it. We advise to work with it alongside ChildProject. Follow the instructions in the section "Datalad installation" to get it as well.
+ - **ChildProject** (and dependencies), the package that is documented here, follow the main installation instructions to get it
+ - **DataLad** (and dependencies), a python software for the management and delivery of scientific data. Although ChildProject may work without it, a number of datasets of daylong recordings of children require it. We advise to work with it alongside ChildProject. Follow the instructions in the section "Datalad installation" to get it as well.
 
 This installation procedure requires a package able to handle conda environments. We recommend using `micromamba <https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html>`__
 but you can use any alternative. A very common alternative is anaconda (conda command). If you are not sure you have conda or
@@ -23,40 +26,40 @@ micromamba installed, check the :ref:`environment_manager_section`.
     All our instructions use ``micromamba`` commands, if you are using a difference environment manager, such as anaconda
     , replace all instructions with the proper command (``conda`` for example).
 
-Automatic install
-~~~~~~~~~~~~~~~~~
-
-Reminder, for running the automatic install, you need an :ref:`environment_manager_section` environment manager to be installed
-
-.. tabs::
-
-   .. group-tab:: linux
-
-      To install automatically in Linux run in a terminal
-
-      .. code-block:: bash
-
-         "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
-
-   .. group-tab:: MacOS
-
-      To install automatically in MacOS run in a terminal
-
-      .. code-block:: bash
-
-         "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
-
-   .. group-tab:: Windows
-
-      To install automatically in Linux, MacOS run in a terminal
-
-      .. code-block:: powershell
-
-         Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.ps1 -UseBasicParsing).Content)
-
-
-Manual install
-~~~~~~~~~~~~~~
+.. Automatic install
+.. ~~~~~~~~~~~~~~~~~
+..
+.. Reminder, for running the automatic install, you need an :ref:`environment_manager_section` environment manager to be installed
+..
+.. .. tabs::
+..
+..    .. group-tab:: linux
+..
+..       To install automatically in Linux run in a terminal
+..
+..       .. code-block:: bash
+..
+..          "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
+..
+..    .. group-tab:: MacOS
+..
+..       To install automatically in MacOS run in a terminal
+..
+..       .. code-block:: bash
+..
+..          "${SHELL}" <(curl -L https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.sh)
+..
+..    .. group-tab:: Windows
+..
+..       To install automatically in Linux, MacOS run in a terminal
+..
+..       .. code-block:: powershell
+..
+..          Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/install.ps1 -UseBasicParsing).Content)
+..
+..
+.. Manual install
+.. ~~~~~~~~~~~~~~
 
 .. tabs::
 
@@ -75,6 +78,8 @@ Manual install
 
    .. group-tab:: MacOS
 
+      Use a terminal window
+
       .. code-block:: bash
 
          # download the conda environment
@@ -86,10 +91,11 @@ Manual install
          # activate the environment (this should be done systematically to use our package)
          micromamba activate childproject
 
-         # install git-annex from brew
-         brew install git-annex
 
    .. group-tab:: Windows
+
+      Use powershell if conda/micromamba is installed as a command, or use the anaconda/miniconda powershell prompt
+      program if conda is installed as a program.
 
       .. code-block:: powershell
 
@@ -102,16 +108,19 @@ Manual install
          # activate the environment (this should be done systematically to use our package)
          micromamba activate childproject
 
-         # install git-annex using uv tool
-         uv tool install git-annex
 
+Installation as system packages and separated python packages
+-------------------------------------------------------------
 
-Installation in the system packages
------------------------------------
+Installing directly dependencies as system packages is not recommended as this won't clearly separate dependencies
+between projects and requires you to have administrator privileges.
 
-Installing directly into the system is not recommended for non admins and beginners. This won't clearly separate your
- python packages depending on projects and will require packages at the system level to be installed
- (requiring administrator permissions) such as sox and ffmpeg.
+Instructions here will install the system dependencies directly into the operating system, the python requirements will
+be installed separately (as installing python packages directly in the system is highly discouraged as
+it could break system packages, still installing directly is possible by replacing `pipx` with `pip` and passing the
+`--break-system-packages` flag.) In windows, those intructions guide you into installing the python packages in anaconda
+prompt.
+
 
 .. tabs::
 
@@ -123,26 +132,31 @@ Installing directly into the system is not recommended for non admins and beginn
 
       .. code-block:: bash
 
-        sudo apt-get install sox ffmpeg git git-annex
+        sudo apt-get install sox ffmpeg git git-annex pipx
 
       Installing packages on Fedora/RHEL/CentOS/Rocky
 
       .. code-block:: bash
 
-        sudo yum install sox ffmpeg git git-annex
+        # if the EPEL is not added on your system, you may need to add it with
+        # sudo dnf install epel-release -y
+        # sudo crb enable
+        # sudo dnf install rpmfusion-free-release -y
+
+        sudo dnf install sox ffmpeg git git-annex pipx
 
       Installing packages on Arch
 
       .. code-block:: bash
 
-        sudo pacman -S install sox ffmpeg git git-annex
+        sudo pacman -S sox ffmpeg git git-annex pipx
 
-
-      Then python packages can be installed with pip directly (or alternatives like uv)
+      Then python packages can be installed with pipx directly (or alternatives like uv)
 
       .. code-block:: bash
 
-        pip install -U datalad ChildProject
+        pipx install datalad
+        pipx install ChildProject
 
    .. group-tab:: MacOS
 
@@ -151,9 +165,10 @@ Installing directly into the system is not recommended for non admins and beginn
       .. code-block:: bash
 
          # install via brew, git should be installed by default
-         brew install sox ffmpeg git-annex
+         brew install sox ffmpeg git-annex pipx
 
-         pip install -U datalad ChildProject
+         pipx install datalad
+         pipx install ChildProject
 
    .. group-tab:: Windows
 
@@ -229,26 +244,22 @@ Installing directly into the system is not recommended for non admins and beginn
 
 
 Check the setup
-~~~~~~~~~~~~~~~
+---------------
 
 You can now make sure the packages have been successfully installed:
-Each --version command should output the version of the package.
+each --version command should output the version of the package.
 If you installed in an environment, check it is activated or activate it
 
 .. clidoc::
 
    child-project --version
-
-.. clidoc::
-
-    # run this ONLY IF you have installed the optional software datalad, for getting and sharing data
-    datalad --version
+   datalad --version
 
 .. note::
 
     We recommend that you regularly keep DataLad and our package up to date. 
-    To force-upgrade this package, do ``pip uninstall ChildProject``
-    and then ``pip install ChildProject --upgrade``.
+    To upgrade this package, do ``pip install ChildProject --upgrade`` in virtual environments, or
+    ``pipx upgrade ChildProject`` if installed directly.
 
     You may also want to install the development version from GitHub in order
     to receive more recent updates before their release:
@@ -258,26 +269,43 @@ If you installed in an environment, check it is activated or activate it
         pip install git+https://github.com/LAAC-LSCP/ChildProject.git --force-reinstall
 
     Since some updates may break compatibility with previous versions,
-    we advise you to read the `Change Log <https://github.com/LAAC-LSCP/ChildProject/blob/master/CHANGELOG.md>`_
+    we advise you to read the `Change Log <https://github.com/LAAC-LSCP/ChildProject/blob/master/CHANGELOG.md>`__
     before upgrading.
     
     DataLad can also be upgraded with ``pip install datalad --upgrade``
     (see DataLad's documentation for more details).
 
+.. _environment_manager_section:
+
 Check and or install Anaconda / Micromamba
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------
 
 To check if conda or micromamba is installed, run in a terminal or powershell the following commands :
-``conda --version`` and ``micromamba --version``
+``conda --version`` and ``micromamba --version``. If either command prints a version number, they are installed and
+you should be able to use them.
 
-If either print a version number, they are installed and you should be able to use them.
+On windows, you may have a 'prompt' version of anaconda install, search for 'powershell anaconda prompt' in your
+programs, launch it to use a terminal where cona is available.
 
-If none is installed, refe to the installation instructions:
- - micromamba follow instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`__.
- - conda follow instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__.
+If none is installed, refer to the installation instructions:
+
+Micromamba
+~~~~~~~~~~
+
+Micromamba is a standalone executable that can be installed directly in a terminal using one instruction. On Windows,
+ use preferably the Powershell option. Follow the instructions `here <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html#automatic-install>`__.
+ Installing micromamba may not require admin privileges.
+
+Miniconda
+~~~~~~~~~
+
+Miniconda is installed as a program, which means you need admin rights. It is then accessible in the terminal on
+Linux/MacOS and by launching a program on Windows (miniconda prompt). Follow instructions `here <https://docs.anaconda.com/anaconda/install/index.html>`__
+to install.
+
 
 Troubleshooting
-~~~~~~~~~~~~~~~
+---------------
 
 If you are having trouble installing ChildProject, please look
 for similar issues on our GithHub (in `Issues <https://github.com/LAAC-LSCP/ChildProject/issues>`__ or `Discussions <https://github.com/LAAC-LSCP/ChildProject/discussions>`__).
@@ -289,7 +317,7 @@ If this issue is related to DataLad, please create an issue on `DataLad's GitHub
 
 
 Frequently Asked Questions
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
     *I don't have anaconda and I can't install it. What should I do?*
 

--- a/env_linux.yml
+++ b/env_linux.yml
@@ -12,3 +12,4 @@ dependencies:
   - sox
   - pip:
     - ChildProject
+    - datalad

--- a/env_macos.yml
+++ b/env_macos.yml
@@ -11,3 +11,5 @@ dependencies:
   - sox
   - pip:
     - ChildProject
+    - git-annex
+    - datalad

--- a/env_windows.yml
+++ b/env_windows.yml
@@ -13,3 +13,5 @@ dependencies:
   - uv
   - pip:
     - ChildProject
+    - git-annex
+    - datalad

--- a/env_windows.yml
+++ b/env_windows.yml
@@ -9,5 +9,7 @@ dependencies:
   - pytest
   - scipy
   - sox
+  - git
+  - uv
   - pip:
     - ChildProject

--- a/env_windows.yml
+++ b/env_windows.yml
@@ -1,0 +1,13 @@
+name: childproject
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.12
+  - ffmpeg
+  - pip
+  - pytest
+  - scipy
+  - sox
+  - pip:
+    - ChildProject

--- a/install.ps1
+++ b/install.ps1
@@ -1,15 +1,6 @@
-# check if VERSION env variable is set, otherwise use "latest"
 $RELEASE_URL = "https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/docs/rework_installation/env_windows.yml"
 
-curl.exe -L -o %TEMP%\env.yml $RELEASE_URL
-
-if (Get-Command git-annex) {
-    echo "Git annex found"
-} else {
-    echo "Git annex not found, installing it..."
-    curl.exe -L -o %TEMP%\git-annex-installer.exe https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe
-    %TEMP%\git-annex-installer.exe
-}
+curl.exe -o $env:TEMP\env.yml $RELEASE_URL
 
 if (Get-Command micromamba) {
     $ENV_MANAGER = "micromamba"
@@ -21,5 +12,17 @@ if (Get-Command micromamba) {
 }
 
 $success = "Installation Completed for environment childproject, activate it with: \n$ENV_MANAGER activate childproject"
-Invoke-Expression ("($ENV_MANAGER env create -f $env:TEMP\env.yml) -and (echo $SUCCESS)")
+# $install = Invoke-Expression ("($ENV_MANAGER env create -f $env:TEMP\env.yml) -and (echo $SUCCESS)")
+micromamba env create -f $env:TEMP\env.yml
+
+if($?)
+{
+   "Installing git-annex"
+   Invoke-Expression ("$ENV_MANAGER activate childproject")
+   uv tool install git-annex
+}
+else
+{
+   "Something went wrong in the environment creation"
+}
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 # check if VERSION env variable is set, otherwise use "latest"
-$RELEASE_URL = "https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_windows.yml"
+$RELEASE_URL = "https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/docs/rework_installation/env_windows.yml"
 
 curl.exe -L -o %TEMP%\env.yml $RELEASE_URL
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,25 @@
+# check if VERSION env variable is set, otherwise use "latest"
+$RELEASE_URL = "https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_windows.yml"
+
+curl.exe -L -o %TEMP%\env.yml $RELEASE_URL
+
+if (Get-Command git-annex) {
+    echo "Git annex found"
+} else {
+    echo "Git annex not found, installing it..."
+    curl.exe -L -o %TEMP%\git-annex-installer.exe https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe
+    %TEMP%\git-annex-installer.exe
+}
+
+if (Get-Command micromamba) {
+    $ENV_MANAGER = "micromamba"
+} elseif (Get-Command conda) {
+    $ENV_MANAGER = "conda"
+} else {
+    echo "not found"
+    exit 1
+}
+
+$success = "Installation Completed for environment childproject, activate it with: \n$ENV_MANAGER activate childproject"
+Invoke-Expression ("($ENV_MANAGER env create -f $env:TEMP\env.yml) -and (echo $SUCCESS)")
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -eu
+
+# Detect the shell from which the script was called
+parent=$(ps -o comm $PPID |tail -1)
+parent=${parent#-}  # remove the leading dash that login shells have
+
+# Computing artifact location
+case "$(uname)" in
+  Linux)
+    PLATFORM="linux" ;;
+  Darwin)
+    PLATFORM="macos" ;;
+  *NT*)
+    PLATFORM="windows" ;;
+esac
+
+RELEASE_URL="https://raw.githubusercontent.com/LAAC-LSCP/ChildProject/master/env_${PLATFORM}.yml"
+
+# find environment manager
+if hash micromamba >/dev/null 2>&1; then
+  ENV_MANAGER="micromamba"
+elif hash conda >/dev/null 2>&1; then
+  ENV_MANAGER="conda"
+else
+  echo "Neither micromamba nor conda was found, get micromamba at https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html" >&2
+  exit 1
+fi
+
+# Downloading artifact
+mkdir -p "${BIN_FOLDER}"
+if hash curl >/dev/null 2>&1; then
+  HTTP_CMD="curl -o"
+elif hash wget >/dev/null 2>&1; then
+  HTTP_CMD="wget -O"
+else
+  echo "Neither curl nor wget was found" >&2
+  exit 1
+fi
+
+eval "${HTTP_CMD} /tmp/env.yml ${RELEASE_URL} && ${ENV_MANAGER} env create -f /tmp/env.yml"
+
+if [ $? -ne 0 ]; then
+  echo "Installation of environment failed with code $?"
+  exit $?
+
+case "$PLATFORM" in
+  macos)
+    brew install git-annex ;;
+  windows)
+    eval "${HTTP_CMD} /tmp/git-annex-installer.exe https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe && ./tmp/git-annex-installer.exe" ;;
+esac
+
+echo "Installation Completed for environment childproject, activate it with: \n${ENV_MANAGER} activate childproject"

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ else
   exit 1
 fi
 
-# Downloading artifact
+# find curl or wget
 mkdir -p "${BIN_FOLDER}"
 if hash curl >/dev/null 2>&1; then
   HTTP_CMD="curl -o"


### PR DESCRIPTION
Rework the installation steps tutorial,

this includes most notably:
- usage of tabs for switching betwenn linux / windows / macos instructions
- instructions for installing inside a conda environment or outside
- changes in the environment yml files to integrate everything, including git-annex. so no need for extra installations on the side anymore

 - [ ] documentation builds without errors