### PR TITLE
feat: add duration std to aclew metrics

### DIFF
--- a/ChildProject/pipelines/metrics.py
+++ b/ChildProject/pipelines/metrics.py
@@ -595,6 +595,7 @@ class AclewMetrics(Metrics):
         segments: Union[str, pd.DataFrame] = None,
         by: str = "recording_filename",
         threads: int = 1,
+        include_std: bool = False,
     ):
         
         self.vtc = vtc
@@ -618,6 +619,14 @@ class AclewMetrics(Metrics):
              ["avg_voc_dur_speaker",self.vtc,'CHI'],
              ["simple_CTC_ph",self.vtc,pd.NA],
              ])
+        
+        if include_std:
+            METRICS = np.concatenate((np.array(
+                [["std_voc_dur_speaker", self.vtc,'FEM'],
+                 ["std_voc_dur_speaker", self.vtc,'MAL'],
+                 ["std_voc_dur_speaker", self.vtc,'OCH'],
+                 ["std_voc_dur_speaker", self.vtc,'CHI']]
+            ), METRICS))
         
         if self.alice not in am.annotations["set"].values:
             print(f"The ALICE set ('{self.alice}') was not found in the index.")
@@ -652,6 +661,13 @@ class AclewMetrics(Metrics):
              ["cp_n",self.vcm,pd.NA],
              ["cp_dur",self.vcm,pd.NA],
              ])))
+            
+            if include_std:
+                METRICS = np.concatenate((METRICS, np.array(
+                    [["std_cry_voc_dur_speaker",self.vcm,"CHI"],
+                     ["std_can_voc_dur_speaker",self.vcm,"CHI"],
+                     ["std_non_can_voc_dur_speaker",self.vcm,"CHI"]]
+                )))
                 
         METRICS = pd.DataFrame(METRICS, columns=["callable","set","speaker"])
 

--- a/ChildProject/pipelines/metricsFunctions.py
+++ b/ChildProject/pipelines/metricsFunctions.py
@@ -207,6 +207,16 @@ def avg_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> floa
     return segments[segments["speaker_type"] == kwargs["speaker"]]["duration"].mean()
 
 
+@metricFunction({"speaker"}, {"speaker_type", "duration"}, np.nan)
+def std_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> float | None:
+    """standard deviation of duration in milliseconds of vocalizations for a given speaker type 
+    
+    Required keyword arguments:
+        - speaker : speaker_type to use
+    """
+    return segments[segments["speaker_type"] == kwargs["speaker"]]["duration"].std()
+
+
 def wc_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> float:
     """number of words for a given speaker type
     
@@ -350,6 +360,20 @@ def avg_cry_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> 
     return value
 
 
+@metricFunction({"speaker"}, ({"speaker_type", "vcm_type", "duration"}, {'speaker_type', "child_cry_vfx_len", "cries"}), np.nan)
+def std_cry_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> float | None:
+    """standard deviation of duration of cry vocalizations by a given speaker type (based on vcm_type or lena cries)
+    
+    Required keyword arguments:
+        - speaker : speaker_type to use
+    """
+    if 'vcm_type' in segments.columns and 'duration' in segments.columns:
+        value = segments.loc[(segments["speaker_type"] == kwargs["speaker"]) &
+                                (segments["vcm_type"] == "Y")]["duration"].std()
+
+    return value
+
+
 def can_voc_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> int:
     """number of canonical vocalizations for a given speaker type (based on vcm_type)
     
@@ -392,6 +416,18 @@ def avg_can_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> 
     value = segments.loc[(segments["speaker_type"] == kwargs["speaker"]) & (segments["vcm_type"] == "C")][
         "duration"].mean()
     if pd.isnull(value): value = 0
+    return value
+
+
+@metricFunction({"speaker"}, {"speaker_type", "vcm_type", "duration"}, np.nan)
+def std_can_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> float | None:
+    """standard deviation of duration of canonical vocalizations for a given speaker type (based on vcm_type)
+    
+    Required keyword arguments:
+        - speaker : speaker_type to use
+    """
+    value = segments.loc[(segments["speaker_type"] == kwargs["speaker"]) & (segments["vcm_type"] == "C")][
+        "duration"].std()
     return value
 
 
@@ -440,6 +476,18 @@ def avg_non_can_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs)
                             (segments["vcm_type"] == "N")]["duration"].mean()
     if pd.isnull(value):
         value = 0
+    return value
+
+
+@metricFunction({"speaker"}, {"speaker_type", "vcm_type", "duration"}, np.nan)
+def std_non_can_voc_dur_speaker(segments: pd.DataFrame, duration: int, **kwargs) -> float | None:
+    """standard deviation of duration of non-canonical vocalizations for a given speaker type (based on vcm_type)
+    
+    Required keyword arguments:
+        - speaker : speaker_type to use
+    """
+    value = segments.loc[(segments["speaker_type"] == kwargs["speaker"]) &
+                            (segments["vcm_type"] == "N")]["duration"].std()
     return value
 
 


### PR DESCRIPTION
Add duration std to aclew metrics

For simplicity I'll keep it out of the CLI as it's quite a niche thing, but let me know if you want it added.

I tested it out using a custom script but no automated test has been made for this feature.