### PR TITLE
revert small change in acoustics-refactor pr

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -9,7 +9,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-15-intel, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12','3.13']
     name: Tests-macos
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I had a look at the old PR I made for acoustics

https://github.com/LAAC-LSCP/ChildProject/pull/535/changes

Everything looks good, including the zooniverse change, but the change on line 129 in release-tests.yml made me raise an eyebrow. I remember pushing these changes in a hurry during a plenary meeting, so not surprised if it's a mistake.